### PR TITLE
Remove redundant Docker Compose prefixes and reflect ability to run `rails s`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,1 @@
-DATABASE_URL=postgres://postgres@db:5432
-
+DATABASE_URL=postgres://postgres@127.0.0.1:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,13 @@
 version: "3.9"
 services:
-  web:
-    build:
-      context: .
-    volumes:
-      - .:/app
-    links:
-      - db
-    ports:
-      - '3000:3000'
-    env_file:
-      - .env
-
   db:
     image: postgres:15.3
     ports: 
       - '5432:5432'
     volumes:
-      - hackathons-postgres:/var/lib/postgresql/data
+      - postgres:/var/lib/postgresql/data
     environment:
       - POSTGRES_HOST_AUTH_METHOD=trust
 
 volumes:
-  hackathons-postgres:
-
+  postgres:


### PR DESCRIPTION
Docker Compose adds prefixes to services scoped by project. And thanks to importmaps, we no longer have to orchestrate separate processes for development or production! Thus, raw `rails s` works fine.