### PR TITLE
Fix failing Dependabot checks due to missing master key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,4 @@ jobs:
         with:
           bundler-cache: true
       - name: Run Standard
-        run: rake standard
-        env:
-          RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
+        run: bundle exec standardrb


### PR DESCRIPTION
We don't need it for any checks as of now, and hopefully, we can have appropriate mocks and stubs for any external calls so that anyone can run tests without credentials in the future.