### PR TITLE
Allow for a HOST env var

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,7 @@ module Hackathons
     # config.eager_load_paths << Rails.root.join("extras")
 
     config.action_mailer.default_url_options = {
-      host: Rails.application.credentials.default_url_host[Rails.env]
+      host: ENV["HOST"] || Rails.application.credentials.dig(:default_url_host, Rails.env) || "localhost:3000"
     }
     config.action_mailer.default_options = {
       from: "hackathons@hackclub.com"


### PR DESCRIPTION
This can differ for between developers, so it makes sense for more configurable options to utilize environment variables.