### PR TITLE
Run Dependabot on Monday instead of Wednesday

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,6 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-      day: "wednesday"
+      day: "monday"
       time: "10:00"
       timezone: "America/New_York"


### PR DESCRIPTION
This spaces things out between runs on other repos.