### PR TITLE
Implement authentication

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,4 @@
 class ApplicationController < ActionController::Base
+  include SetCurrentRequestDetails
+  include Authenticate
 end

--- a/app/controllers/concerns/authenticate.rb
+++ b/app/controllers/concerns/authenticate.rb
@@ -1,0 +1,25 @@
+module Authenticate
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :authenticate
+    before_action :redirect_if_unauthenticated
+  end
+
+  private
+
+  def authenticate
+    if (session = User::Session.find_by(token: cookies.encrypted[:session_token]))
+      session.access
+      Current.session = session
+    end
+  end
+
+  def redirect_if_unauthenticated
+    redirect_to sign_in_path unless Current.user
+  end
+
+  def redirect_if_authenticated
+    redirect_to root_path if Current.user
+  end
+end

--- a/app/controllers/concerns/set_current_request_details.rb
+++ b/app/controllers/concerns/set_current_request_details.rb
@@ -1,0 +1,11 @@
+module SetCurrentRequestDetails
+  extend ActiveSupport::Concern
+
+  included do
+    before_action do
+      Current.request_id = request.uuid
+      Current.user_agent = request.user_agent
+      Current.ip_address = request.remote_ip
+    end
+  end
+end

--- a/app/controllers/hackathons_controller.rb
+++ b/app/controllers/hackathons_controller.rb
@@ -1,5 +1,5 @@
 class HackathonsController < ApplicationController
-  # skip_before_action :redirect_if_unauthenticated
+  skip_before_action :redirect_if_unauthenticated
 
   def index
   end

--- a/app/controllers/hackathons_controller.rb
+++ b/app/controllers/hackathons_controller.rb
@@ -1,0 +1,6 @@
+class HackathonsController < ApplicationController
+  # skip_before_action :redirect_if_unauthenticated
+
+  def index
+  end
+end

--- a/app/controllers/users/authentications_controller.rb
+++ b/app/controllers/users/authentications_controller.rb
@@ -1,0 +1,13 @@
+class Users::AuthenticationsController < ApplicationController
+  skip_before_action :redirect_if_unauthenticated
+
+  def new
+  end
+
+  def create
+    @user = User.find_or_create_by(email_address: params[:email_address])
+    @user&.authentications&.create! if @user.persisted?
+
+    render :new, status: :unprocessable_entity
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,24 @@
+class Users::SessionsController < ApplicationController
+  skip_before_action :redirect_if_unauthenticated, except: :destroy
+  before_action :redirect_if_authenticated, except: :destroy
+
+  def new
+    if (authentication = User::Authentication.find_by(token: params[:auth_token]))
+      return redirect_to sign_in_path if authentication.expired? || authentication.succeeded?
+
+      authentication.complete
+      session = authentication.create_session!
+
+      cookies.encrypted[:session_token] = session.token
+      redirect_to root_path
+    else
+      redirect_to sign_in_path
+    end
+  end
+
+  def destroy
+    Current.session.destroy!
+    cookies.encrypted[:session_token] = nil
+    redirect_to root_path
+  end
+end

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,4 +1,4 @@
 class ApplicationMailer < ActionMailer::Base
-  default from: "from@example.com"
+  default from: "hackathons@hackclub.com"
   layout "mailer"
 end

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,0 +1,8 @@
+class UserMailer < ApplicationMailer
+  def authentication
+    @authentication = params[:authentication]
+    @user = @authentication.user
+
+    mail to: @user.email_address, subject: "Sign in to Hackathons"
+  end
+end

--- a/app/models/concerns/deliverable.rb
+++ b/app/models/concerns/deliverable.rb
@@ -1,0 +1,20 @@
+module Deliverable
+  extend ActiveSupport::Concern
+  extend Suppressible
+
+  included do
+    after_create_commit :deliver_later, unless: -> { Deliverable.suppressed? }
+  end
+
+  def deliver_later
+    delivery.deliver_later
+  end
+
+  def deliver_now
+    delivery.deliver_now
+  end
+
+  def delivery
+    raise NotImplementedError
+  end
+end

--- a/app/models/concerns/suppressible.rb
+++ b/app/models/concerns/suppressible.rb
@@ -1,0 +1,17 @@
+module Suppressible
+  def self.registry
+    ActiveSupport::IsolatedExecutionState[:suppressible_registry] ||= {}
+  end
+
+  def suppress
+    previous_state = Suppressible.registry[name]
+    Suppressible.registry[name] = true
+    yield
+  ensure
+    Suppressible.registry[name] = previous_state
+  end
+
+  def suppressed?
+    !!Suppressible.registry[name]
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,9 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :user
+  attribute :request_id, :user_agent, :ip_address
+  attribute :user, :session
+
+  def session=(session)
+    super
+    self.user = session&.user
+  end
 end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,4 +1,6 @@
 class Event < ApplicationRecord
+  include Requested
+
   belongs_to :eventable, polymorphic: true
 
   belongs_to :creator, class_name: "User", optional: true

--- a/app/models/event/request.rb
+++ b/app/models/event/request.rb
@@ -1,0 +1,7 @@
+class Event::Request < ApplicationRecord
+  belongs_to :event
+
+  validates :uuid, presence: true
+  validates :user_agent, presence: true
+  validates :ip_address, presence: true
+end

--- a/app/models/event/requested.rb
+++ b/app/models/event/requested.rb
@@ -1,0 +1,19 @@
+module Event::Requested
+  extend ActiveSupport::Concern
+
+  included do
+    has_one :request, dependent: :destroy
+
+    after_create :attach_request
+  end
+
+  private
+
+  def attach_request
+    create_request(
+      uuid: Current.request_id,
+      user_agent: Current.user_agent,
+      ip_address: Current.ip_address
+    )
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ApplicationRecord
   include Eventable
 
+  include Authenticatable
   include Identifiable
   include Named
   include Privileged

--- a/app/models/user/authenticatable.rb
+++ b/app/models/user/authenticatable.rb
@@ -1,0 +1,8 @@
+module User::Authenticatable
+  extend ActiveSupport::Concern
+
+  included do
+    has_many :authentications, dependent: :destroy
+    has_many :sessions, through: :authentications
+  end
+end

--- a/app/models/user/authentication.rb
+++ b/app/models/user/authentication.rb
@@ -1,0 +1,29 @@
+class User::Authentication < ApplicationRecord
+  include Deliverable
+  include Eventable
+
+  belongs_to :user
+
+  has_secure_token
+  has_one :session, dependent: :destroy
+
+  def expired?
+    created_at + AUTHENTICATION_VALIDITY_PERIOD < Time.now
+  end
+
+  def succeeded?
+    events.where(action: :completed).exists?
+  end
+
+  def complete
+    record(:completed)
+  end
+
+  def delivery
+    UserMailer.with(authentication: self).authentication
+  end
+
+  private
+
+  AUTHENTICATION_VALIDITY_PERIOD = 1.hour
+end

--- a/app/models/user/authentication.rb
+++ b/app/models/user/authentication.rb
@@ -16,7 +16,7 @@ class User::Authentication < ApplicationRecord
   end
 
   def complete
-    record(:completed)
+    record(:completed, by: user)
   end
 
   def delivery

--- a/app/models/user/named.rb
+++ b/app/models/user/named.rb
@@ -2,7 +2,6 @@ module User::Named
   extend ActiveSupport::Concern
 
   included do
-    validates :name, presence: true
     encrypts :name
   end
 end

--- a/app/models/user/session.rb
+++ b/app/models/user/session.rb
@@ -1,0 +1,10 @@
+class User::Session < ApplicationRecord
+  belongs_to :authentication
+  delegate :user, to: :authentication
+
+  has_secure_token
+
+  def access
+    touch(:last_accessed_at)
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
+    <%= stylesheet_link_tag "https://cdn.simplecss.org/simple.min.css", "data-turbo-track": "reload" %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>

--- a/app/views/user_mailer/authentication.html.erb
+++ b/app/views/user_mailer/authentication.html.erb
@@ -1,1 +1,3 @@
-<%= link_to "Sign In!", new_session_url(auth_token: @authentication.token) %>
+Here's your <%= link_to "sign in link", new_session_url(auth_token: @authentication.token) %>:
+
+<%= link_to nil, new_session_url(auth_token: @authentication.token) %>

--- a/app/views/user_mailer/authentication.html.erb
+++ b/app/views/user_mailer/authentication.html.erb
@@ -1,3 +1,1 @@
-Here's your sign in link:
-
-<%= link_to new_session_url(auth_token: @authentication.token) %>
+<%= link_to "Sign In!", new_session_url(auth_token: @authentication.token) %>

--- a/app/views/user_mailer/authentication.html.erb
+++ b/app/views/user_mailer/authentication.html.erb
@@ -1,0 +1,3 @@
+Here's your sign in link:
+
+<%= link_to new_session_url(auth_token: @authentication.token) %>

--- a/app/views/user_mailer/authentication.text.erb
+++ b/app/views/user_mailer/authentication.text.erb
@@ -1,3 +1,3 @@
 Here's your sign in link:
 
-<%= link_to nil, new_session_url(auth_token: @authentication.token) %>
+<%= new_session_url(auth_token: @authentication.token) %>

--- a/app/views/user_mailer/authentication.text.erb
+++ b/app/views/user_mailer/authentication.text.erb
@@ -1,0 +1,3 @@
+Here's your sign in link:
+
+<%= link_to nil, new_session_url(auth_token: @authentication.token) %>

--- a/app/views/users/authentications/new.html.erb
+++ b/app/views/users/authentications/new.html.erb
@@ -1,0 +1,14 @@
+<h2>Sign In</h2>
+
+<%= turbo_frame_tag :authentication, target: "_top" do %>
+  <% if @user&.persisted? %>
+    <p class="notice">
+      An email has been sent to <strong><%= @user.email_address %></strong> with a link to sign in.
+    </p>
+  <% else %>
+    <%= form_with url: authentication_path do |form| %>
+      <%= form.text_field :email_address, placeholder: "orpheus@hackclub.test" %>
+      <%= form.button "Send Sign In Link" %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,11 @@
 Rails.application.routes.draw do
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+  root "hackathons#index"
 
-  # Defines the root path route ("/")
-  # root "articles#index"
+  get "sign_in", to: "users/authentications#new", as: :sign_in
+  scope :my, module: :users do
+    resource :authentication, only: [:create, :show]
+    resources :sessions, only: [:new, :destroy]
+  end
 
   mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 end

--- a/db/migrate/20230718223502_create_user_sessions.rb
+++ b/db/migrate/20230718223502_create_user_sessions.rb
@@ -1,0 +1,21 @@
+class CreateUserSessions < ActiveRecord::Migration[7.0]
+  def change
+    create_table :user_authentications do |t|
+      t.belongs_to :user, null: false, foreign_key: true
+
+      t.string :token, null: false, index: true
+
+      t.timestamps
+    end
+
+    create_table :user_sessions do |t|
+      t.references :authentication, null: false, foreign_key: {to_table: :user_authentications}
+
+      t.string :token, null: false, index: true
+
+      t.timestamp :last_accessed_at
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230718223503_create_event_requests.rb
+++ b/db/migrate/20230718223503_create_event_requests.rb
@@ -1,0 +1,13 @@
+class CreateEventRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :event_requests do |t|
+      t.references :event, null: false, foreign_key: true
+
+      t.string :uuid
+      t.string :user_agent
+      t.string :ip_address
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_18_091913) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_18_223503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "event_requests", force: :cascade do |t|
+    t.bigint "event_id", null: false
+    t.string "uuid"
+    t.string "user_agent"
+    t.string "ip_address"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_event_requests_on_event_id"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "eventable_type"
@@ -69,6 +79,25 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_091913) do
     t.index ["name"], name: "index_tags_on_name"
   end
 
+  create_table "user_authentications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "token", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["token"], name: "index_user_authentications_on_token"
+    t.index ["user_id"], name: "index_user_authentications_on_user_id"
+  end
+
+  create_table "user_sessions", force: :cascade do |t|
+    t.bigint "authentication_id", null: false
+    t.string "token", null: false
+    t.datetime "last_accessed_at", precision: nil
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["authentication_id"], name: "index_user_sessions_on_authentication_id"
+    t.index ["token"], name: "index_user_sessions_on_token"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email_address", null: false
     t.string "name"
@@ -79,6 +108,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_18_091913) do
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
   end
 
+  add_foreign_key "event_requests", "events"
   add_foreign_key "events", "users", column: "creator_id"
   add_foreign_key "events", "users", column: "target_id"
+  add_foreign_key "user_authentications", "users"
+  add_foreign_key "user_sessions", "user_authentications", column: "authentication_id"
 end

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,5 @@
 require "test_helper"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
 end

--- a/test/system/authentication_flow_test.rb
+++ b/test/system/authentication_flow_test.rb
@@ -1,12 +1,6 @@
 require "application_system_test_case"
 
 class AuthenticationFlowTest < ApplicationSystemTestCase
-  test "trying to view root page unauthenticated" do
-    visit root_path
-
-    assert_current_path sign_in_path
-  end
-
   test "requesting a sign in link" do
     visit sign_in_path
 

--- a/test/system/authentication_flow_test.rb
+++ b/test/system/authentication_flow_test.rb
@@ -1,0 +1,43 @@
+require "application_system_test_case"
+
+class AuthenticationFlowTest < ApplicationSystemTestCase
+  test "trying to view root page unauthenticated" do
+    visit root_path
+
+    assert_current_path sign_in_path
+  end
+
+  test "requesting a sign in link" do
+    visit sign_in_path
+
+    fill_in :email_address, with: "matt7@hey.test"
+    click_on "Send Sign In Link"
+
+    assert User.where(email_address: "matt7@hey.test").exists?
+
+    assert_text(/sent/i)
+    assert_text(/matt7@hey\.test/)
+  end
+
+  test "using an invalid link" do
+    user = users(:matt)
+    authentication = user.authentications.create!
+
+    travel 1.day
+
+    visit new_session_path(auth_token: authentication.token)
+
+    assert_current_path sign_in_path
+  end
+
+  test "using a valid link" do
+    user = users(:matt)
+    authentication = user.authentications.create!
+
+    assert_difference -> { user.sessions.count } do
+      visit new_session_path(auth_token: authentication.token)
+    end
+
+    assert_no_current_path sign_in_path
+  end
+end


### PR DESCRIPTION
## Domain Model

#### A `User` is now `Authenticatable`, with `Session`s through `Authentication`s.

- When a `User` requests a sign in link with their email, an `Authentication` is created.
- An `Authentication` is `Deliverable`, through it's `delivery`, a mailer. (we create a global concern to utilize this common abstraction in the future).
- An `Authentication` `has_secure_token`, which is a part of the link that gets sent.
- When a valid `Authentication#complete`s, its newly-created `Session` `has_secure_token` that gets stored in an encrypted cookie.
- When a request comes in, the controller(s) `Authenticate` it by querying `Session`s with the token.

#### `Request`s are now saved with their associated events.

- The `Current.request_id`, `user_agent`, and `ip_address` get saved every time there's an `Event` with those details.

#### Concerns (and any entities, really) can now be `Suppressible`

This was inspired by [DHH's video on concerns](https://youtu.be/M3JPTOTqsnE?t=1139) and [ActiveRecord's suppressor](https://github.com/rails/rails/issues/18847). It alleviates one of the main disadvantages of concerns: sometimes there will be edge cases where you don't want the default behavior that usually happens on the side (like sending a bunch of notifications when migrating existing hackathons, etc., which is a perfectly valid point).