### PR TITLE
Change config to allow for Spring in test environment

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -9,7 +9,8 @@ Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
   # Turn false under Spring and add config.action_view.cache_template_loading = true.
-  config.cache_classes = true
+  config.cache_classes = !(defined?(Spring::Env) && Spring::Env.new.server_running?)
+  config.action_view.cache_template_loading = true unless config.cache_classes
 
   # Eager loading loads your whole application. When running a single test locally,
   # this probably isn't necessary. It's a good idea to do in a continuous integration


### PR DESCRIPTION
```
/Users/garyhtou/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/spring-4.1.1/lib/spring/application.rb:100:in `block in preload': Spring reloads, and therefore needs the application to have reloading enabled.
Please, set config.cache_classes to false in config/environments/test.rb.
```

https://github.com/rails/spring/issues/598#issuecomment-1268885973