### PR TITLE
Add Applicant to Hackathons

### DIFF
--- a/app/models/hackathon.rb
+++ b/app/models/hackathon.rb
@@ -6,4 +6,5 @@ class Hackathon < ApplicationRecord
   include Named
   include Regional
   include Scheduled
+  include Applicant
 end

--- a/app/models/hackathon/applicant.rb
+++ b/app/models/hackathon/applicant.rb
@@ -1,0 +1,7 @@
+module Hackathon::Applicant
+  extend ActiveSupport::Concern
+
+  included do
+    belongs_to :applicant, class_name: "User"
+  end
+end

--- a/db/migrate/20230718235719_add_applicant_to_hackathons.rb
+++ b/db/migrate/20230718235719_add_applicant_to_hackathons.rb
@@ -1,0 +1,5 @@
+class AddApplicantToHackathons < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :hackathons, :applicant, null: false, foreign_key: {to_table: :users}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -81,7 +81,9 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_015234) do
     t.string "street"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "applicant_id", null: false
     t.index ["address"], name: "index_hackathons_on_address"
+    t.index ["applicant_id"], name: "index_hackathons_on_applicant_id"
     t.index ["country_code", "city"], name: "index_hackathons_on_country_code_and_city"
     t.index ["country_code", "province", "city"], name: "index_hackathons_on_country_code_and_province_and_city"
     t.index ["latitude", "longitude"], name: "index_hackathons_on_latitude_and_longitude"
@@ -141,6 +143,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_19_015234) do
   add_foreign_key "event_requests", "events"
   add_foreign_key "events", "users", column: "creator_id"
   add_foreign_key "events", "users", column: "target_id"
+  add_foreign_key "hackathons", "users", column: "applicant_id"
   add_foreign_key "user_authentications", "users"
   add_foreign_key "user_sessions", "user_authentications", column: "authentication_id"
 end

--- a/test/fixtures/hackathons.yml
+++ b/test/fixtures/hackathons.yml
@@ -2,3 +2,4 @@ test_hacks:
   name: TestHacks
   starts_at: <%= Time.now %>
   ends_at: <%= 1.day.from_now %>
+  applicant: gary

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -7,3 +7,8 @@ peasant_matt:
   name: Matt Almeida
   email_address: matt7@hey.test
   admin: false
+
+gary:
+  name: Gary Tou
+  email_address: gary@hackclub.com
+  admin: true

--- a/test/models/hackathon/regional_test.rb
+++ b/test/models/hackathon/regional_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Hackathon::RegionalTest < ActiveSupport::TestCase
   test "creating a hackathon with seperated location attributes" do
-    hackathon = Hackathon.new name: "HQHacks", starts_at: Time.now, ends_at: 1.day.from_now
+    hackathon = Hackathon.new name: "HQHacks", starts_at: Time.now, ends_at: 1.day.from_now, applicant: users(:gary)
 
     Geocoder::Lookup::Test.add_stub(
       "15 Falls Road, Shelburne, Vermont", [{"coordinates" => [44.3803059, -73.2271145]}]
@@ -33,7 +33,7 @@ class Hackathon::RegionalTest < ActiveSupport::TestCase
   end
 
   test "creating a hackathon with a full address" do
-    hackathon = Hackathon.new name: "HQHacks", starts_at: Time.now, ends_at: 1.day.from_now
+    hackathon = Hackathon.new name: "HQHacks", starts_at: Time.now, ends_at: 1.day.from_now, applicant: users(:gary)
 
     Geocoder::Lookup::Test.add_stub(
       "15 Falls Road, VT", [{"coordinates" => [44.3803059, -73.2271145]}]

--- a/test/models/hackathon_test.rb
+++ b/test/models/hackathon_test.rb
@@ -2,14 +2,34 @@ require "test_helper"
 
 class HackathonTest < ActiveSupport::TestCase
   test "creating a hackathon with invalid dates" do
-    hackathon = Hackathon.new name: "TestHacks", starts_at: Time.now, ends_at: 2.days.ago
+    hackathon = Hackathon.new(
+      name: "TestHacks",
+      starts_at: Time.now,
+      ends_at: 2.days.ago,
+      applicant: users(:gary)
+    )
 
     assert_not hackathon.save
   end
 
   test "creating a hackathon" do
-    hackathon = Hackathon.new name: "TestHacks", starts_at: Time.now, ends_at: 2.days.from_now
+    hackathon = Hackathon.new(
+      name: "TestHacks",
+      starts_at: Time.now,
+      ends_at: 2.days.from_now,
+      applicant: users(:gary)
+    )
 
     assert hackathon.save
+  end
+
+  test "creating a hackathon without an applicant" do
+    hackathon = Hackathon.new(
+      name: "TestHacks",
+      starts_at: Time.now,
+      ends_at: 2.days.from_now
+    )
+
+    assert_not hackathon.save
   end
 end


### PR DESCRIPTION
The main reason is to just have an `email` associated with a Hackathon