### PR TITLE
API: error classes for NotFound and InvalidApiVersion

### DIFF
--- a/app/controllers/api/concerns/errors.rb
+++ b/app/controllers/api/concerns/errors.rb
@@ -21,23 +21,20 @@ module Api::Concerns::Errors
 
   def unsupported_version(error)
     api_version = params[:api_version]
+    detail = "API version v#{api_version} is not supported."
 
-    render_error error, type: :invalid_api_version_error,
-      title: "Unsupported API version",
-      detail: "API version v#{api_version} is not supported."
+    api_error ::Api::InvalidApiVersionError.new(detail:, backtrace: error.backtrace)
   end
 
   def not_found(error)
-    model_name = error.try(:model) || "resource"
+    model_name = error.try(:model) || "object"
     id = error.try(:id) || params[:id]
 
     detail = "The requested #{model_name}"
     detail += " with id='#{id}'" if id
     detail += " could not be found."
 
-    render_error error, type: :not_found_error, status: :not_found,
-      title: "Object not found",
-      detail:
+    api_error ::Api::NotFoundError.new(detail:, backtrace: error.backtrace)
   end
 
   def server_error(error)

--- a/app/errors/api/bad_request_error.rb
+++ b/app/errors/api/bad_request_error.rb
@@ -3,7 +3,8 @@ class Api::BadRequestError < Api::Error
     title: "Bad Request",
     detail: "you've done a whoopsie!",
     status: :bad_request,
-    type: :bad_request_error
+    type: :bad_request_error,
+    backtrace: nil
   )
     super
   end

--- a/app/errors/api/error.rb
+++ b/app/errors/api/error.rb
@@ -1,11 +1,13 @@
 class Api::Error < StandardError
   attr_reader :title, :detail, :status, :type
 
-  def initialize(title: nil, detail: nil, status: nil, type: nil)
+  def initialize(title: nil, detail: nil, status: nil, type: nil, backtrace: nil)
     @title = title
     @detail = detail
     @status = status
     @type = type
     super(title)
+
+    set_backtrace(backtrace) if backtrace
   end
 end

--- a/app/errors/api/invalid_api_version_error.rb
+++ b/app/errors/api/invalid_api_version_error.rb
@@ -1,0 +1,11 @@
+class Api::InvalidApiVersionError < Api::Error
+  def initialize(
+    title: "Unsupported API version",
+    detail: "API version you requested is not supported.",
+    status: :bad_request,
+    type: :invalid_api_version_error,
+    backtrace: nil
+  )
+    super
+  end
+end

--- a/app/errors/api/not_found_error.rb
+++ b/app/errors/api/not_found_error.rb
@@ -1,0 +1,11 @@
+class Api::NotFoundError < Api::Error
+  def initialize(
+    title: "Not found",
+    detail: "The object you requested could not be found",
+    status: :not_found,
+    type: :not_found_error,
+    backtrace: nil
+  )
+    super
+  end
+end


### PR DESCRIPTION
This helps ensure uniform `type`s and `title`s when reusing these errors elsewhere.