### PR TITLE
Unsubscribe from Subscription via signed url

### DIFF
--- a/app/controllers/hackathon/subscriptions_controller.rb
+++ b/app/controllers/hackathon/subscriptions_controller.rb
@@ -8,6 +8,6 @@ class Hackathon::SubscriptionsController < ApplicationController
     @unsubscribed = @subscription.update!(status: :inactive)
 
     @subscriber = @subscription.subscriber
-    @other_subscriptions = Hackathon::Subscription.active_for(@subscription.subscriber)
+    @other_subscriptions = Hackathon::Subscription.active_for(@subscriber)
   end
 end

--- a/app/controllers/hackathon/subscriptions_controller.rb
+++ b/app/controllers/hackathon/subscriptions_controller.rb
@@ -1,0 +1,13 @@
+class Hackathon::SubscriptionsController < ApplicationController
+  skip_before_action :redirect_if_unauthenticated, only: [:unsubscribe]
+
+  def unsubscribe
+    @subscription = Hackathon::Subscription.find_signed(params[:id], purpose: :unsubscribe)
+    return unless @subscription
+
+    @unsubscribed = @subscription.update!(status: :inactive)
+
+    @subscriber = @subscription.subscriber
+    @other_subscriptions = Hackathon::Subscription.active_for(@subscription.subscriber)
+  end
+end

--- a/app/models/hackathon/subscription/status.rb
+++ b/app/models/hackathon/subscription/status.rb
@@ -9,6 +9,15 @@ module Hackathon::Subscription::Status
     scope :active_for, ->(user) { active.where(subscriber: user) }
   end
 
+  # Unsubscribe URLs must be valid for at least 30 days.
+  # https://www.ftc.gov/business-guidance/resources/can-spam-act-compliance-guide-business
+  UNSUBSCRIBE_EXPIRATION = 2.months
+
+  def unsubscribe_url
+    signature = signed_id purpose: :unsubscribe, expires_in: UNSUBSCRIBE_EXPIRATION
+    Rails.application.routes.url_helpers.unsubscribe_subscription_url(signature)
+  end
+
   private
 
   def track_changes

--- a/app/views/hackathon/subscriptions/unsubscribe.html.erb
+++ b/app/views/hackathon/subscriptions/unsubscribe.html.erb
@@ -1,0 +1,20 @@
+<h1>High School Hackathons</h1>
+<% if @unsubscribed %>
+  <p class="notice">
+    You have unsubscribed from emails regarding hackathons near
+    <b><%= @subscription.location %></b>.
+  </p>
+
+  <% if @other_subscriptions.any? %>
+    <p style="margin-bottom: 0;">
+      <b><%= @subscriber.email_address %></b> is also subscribed to:
+    </p>
+    <ul>
+      <% @other_subscriptions.each do |subscription| %>
+        <li><%= subscription.location %></li>
+      <% end %>
+    </ul>
+  <% end %>
+<% else %>
+  <p>This unsubscribe link has expired.</p>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,14 @@ Rails.application.routes.draw do
     resources :sessions, only: [:new, :destroy]
   end
 
+  scope module: :hackathon do
+    resources :subscriptions, only: [] do
+      member do
+        get "unsubscribe"
+      end
+    end
+  end
+
   namespace :api, defaults: {format: :json} do
     scope "/v:api_version" do
       resources :hackathons, only: [:index, :show]

--- a/test/controllers/hackathon/subscriptions_controller_test.rb
+++ b/test/controllers/hackathon/subscriptions_controller_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class Hackathon::SubscriptionsControllerTest < ActionDispatch::IntegrationTest
+  test "should unsubscribe" do
+    subscription = hackathon_subscriptions(:gary_seattle)
+
+    get subscription.unsubscribe_url
+    assert_response :success
+
+    assert_match "You have unsubscribed", @response.body
+    assert_match subscription.location, @response.body
+  end
+
+  test "should expire" do
+    subscription = hackathon_subscriptions(:gary_seattle)
+
+    unsub_url = subscription.unsubscribe_url
+    expiration_at = Hackathon::Subscription::Status::UNSUBSCRIBE_EXPIRATION.from_now + 1.second
+
+    travel_to expiration_at do
+      get unsub_url
+      assert_response :success
+
+      assert_match "expired", @response.body
+    end
+  end
+
+  test "should handle invalid signature" do
+    subscription = hackathon_subscriptions(:gary_seattle)
+
+    get unsubscribe_subscription_url(subscription) # no signature
+    assert_response :success
+
+    assert_match "expired", @response.body
+  end
+end

--- a/test/controllers/hackathon/subscriptions_controller_test.rb
+++ b/test/controllers/hackathon/subscriptions_controller_test.rb
@@ -1,20 +1,20 @@
 require "test_helper"
 
 class Hackathon::SubscriptionsControllerTest < ActionDispatch::IntegrationTest
-  test "should unsubscribe" do
-    subscription = hackathon_subscriptions(:gary_seattle)
+  setup do
+    @subscription = hackathon_subscriptions(:gary_seattle)
+  end
 
-    get subscription.unsubscribe_url
+  test "should unsubscribe" do
+    get @subscription.unsubscribe_url
     assert_response :success
 
     assert_match "You have unsubscribed", @response.body
-    assert_match subscription.location, @response.body
+    assert_match @subscription.location, @response.body
   end
 
   test "should expire" do
-    subscription = hackathon_subscriptions(:gary_seattle)
-
-    unsub_url = subscription.unsubscribe_url
+    unsub_url = @subscription.unsubscribe_url
     expiration_at = Hackathon::Subscription::Status::UNSUBSCRIBE_EXPIRATION.from_now + 1.second
 
     travel_to expiration_at do
@@ -26,9 +26,7 @@ class Hackathon::SubscriptionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should handle invalid signature" do
-    subscription = hackathon_subscriptions(:gary_seattle)
-
-    get unsubscribe_subscription_url(subscription) # no signature
+    get unsubscribe_subscription_url(@subscription) # no signature
     assert_response :success
 
     assert_match "expired", @response.body

--- a/test/fixtures/hackathon/subscriptions.yml
+++ b/test/fixtures/hackathon/subscriptions.yml
@@ -1,0 +1,7 @@
+gary_seattle:
+  subscriber: gary
+  city: Seattle
+  province: Washington
+  country_code: US
+  latitude: 47.6038321,
+  longitude: -122.330062

--- a/test/models/hackathon/subscription_test.rb
+++ b/test/models/hackathon/subscription_test.rb
@@ -25,7 +25,7 @@ class SubscriptionTest < ActiveSupport::TestCase
       Hackathon::Subscription.create location_input: "05482"
     end
 
-    assert_equal "Shelburne, Vermont, US", Hackathon::Subscription.first.location
+    assert_equal "Shelburne, Vermont, US", Hackathon::Subscription.last.location
   end
 
   test "subscribing for the same area" do


### PR DESCRIPTION
Users can unsubscribe from a `Subscription` using a signed URL. This URL will be sent in `Digest` mailers. It's a simple `GET` to `/subscriptions/:id/unsubscribe`, where `:id` is a [signed id](https://api.rubyonrails.org/classes/ActiveRecord/SignedId.html) with an `unsubscribe` purpose.


Upon visiting an unsubscribe URL, you will see the following:
![image](https://github.com/hackclub/hackathons-backend/assets/20099646/b0408020-3279-46b7-8f9a-693b0916ba5e)

Unsubscribe URLs expire after 2 months.
![image](https://github.com/hackclub/hackathons-backend/assets/20099646/52347bd7-cde0-4031-b89d-f9f36903afd6)


If the signature in the signed id is invalid, the view will show it as an expired URL.

---


**Example URL:**
```
http://localhost:3000/subscriptions/eyJfcmFpbHMiOnsibWVzc2FnZSI6Ik16QT0iLCJleHAiOiIyMDIzLTA5LTI2VDA1OjM3OjQ4LjQ5M1oiLCJwdXIiOiJoYWNrYXRob24vc3Vic2NyaXB0aW9uL3Vuc3Vic2NyaWJlIn19--b3e99639b45f15025099b3241ea287f2f921e3e26b1a168265f0c6578ca9c48b/unsubscribe
```