### PR TITLE
Digest Listing: Logic for searching nearby hackathons

### DIFF
--- a/app/models/hackathon/digest.rb
+++ b/app/models/hackathon/digest.rb
@@ -6,4 +6,15 @@ class Hackathon::Digest < ApplicationRecord
   include Listings
 
   belongs_to :recipient, class_name: "User"
+
+  private
+
+  def delivery
+    # TODO: Implement
+    Class.new do
+      def method_missing(_)
+        # noop
+      end
+    end.new
+  end
 end

--- a/app/models/hackathon/digest.rb
+++ b/app/models/hackathon/digest.rb
@@ -15,6 +15,10 @@ class Hackathon::Digest < ApplicationRecord
       def method_missing(_)
         # noop
       end
+
+      def respond_to_missing?
+        true
+      end
     end.new
   end
 end

--- a/app/models/hackathon/digest/listing.rb
+++ b/app/models/hackathon/digest/listing.rb
@@ -1,4 +1,5 @@
 class Hackathon::Digest::Listing < ApplicationRecord
   belongs_to :digest, class_name: "Hackathon::Digest"
   belongs_to :hackathon
+  belongs_to :subscription
 end

--- a/app/models/hackathon/digest/listings.rb
+++ b/app/models/hackathon/digest/listings.rb
@@ -15,10 +15,9 @@ module Hackathon::Digest::Listings
 
   MAX_LISTINGS = 5
 
-  def build_list_of_relevant_hackathons
-    nearby_upcoming_hackathons.first(MAX_LISTINGS).each do |result|
+  def build_list_of_relevant_hackathons(max_listings: MAX_LISTINGS)
+    nearby_upcoming_hackathons.first(max_listings).each do |result|
       listings.build hackathon: result[:hackathon], subscription: result[:subscription]
-      # listings.create! hackathon: result[:hackathon], subscription: result[:subscription]
     end
   end
 end

--- a/app/models/hackathon/digest/listings.rb
+++ b/app/models/hackathon/digest/listings.rb
@@ -6,6 +6,7 @@ module Hackathon::Digest::Listings
   included do
     has_many :listings, dependent: :destroy
     has_many :listed_hackathons, through: :listings, source: :hackathon
+    has_many :listed_subscriptions, through: :listings, source: :subscription
 
     before_create :build_list_of_relevant_hackathons
   end
@@ -15,8 +16,9 @@ module Hackathon::Digest::Listings
   MAX_LISTINGS = 5
 
   def build_list_of_relevant_hackathons
-    nearby_upcoming_hackathons.first(MAX_LISTINGS).each do |hackathon|
-      listings.create! hackathon: hackathon
+    nearby_upcoming_hackathons.first(MAX_LISTINGS).each do |result|
+      listings.build hackathon: result[:hackathon], subscription: result[:subscription]
+      # listings.create! hackathon: result[:hackathon], subscription: result[:subscription]
     end
   end
 end

--- a/app/models/hackathon/digest/listings/by_location.rb
+++ b/app/models/hackathon/digest/listings/by_location.rb
@@ -33,6 +33,8 @@ module Hackathon::Digest::Listings::ByLocation
     # is really a search for "hackathons near Kansas". So, we only search for
     # nearby hackathons if the location is specific enough (has a most
     # significant component of city).
+    #
+    # Highly recommended video 📺: https://www.youtube.com/watch?v=vh6zanS_epw
     return [] unless location.most_significant_component == :city
 
     upcoming_hackathons

--- a/app/models/hackathon/digest/listings/by_location.rb
+++ b/app/models/hackathon/digest/listings/by_location.rb
@@ -12,7 +12,7 @@ module Hackathon::Digest::Listings::ByLocation
       end
 
       # Searching for hackathons **near** Subscription's location
-      if subscription.to_location.sig_component == :city
+      if subscription.to_location.most_significant_component == :city
         nearby_hackathons = upcoming_hackathons
           .near(subscription.location, 150, units: :mi)
           .where.not(city: [nil, ""])

--- a/app/models/hackathon/regional.rb
+++ b/app/models/hackathon/regional.rb
@@ -10,7 +10,7 @@ module Hackathon::Regional
         hackathon.province = result.province || result.state
         hackathon.city = result.city
         hackathon.address = result.address
-        hackathon.street = [result.try(:house_number), result.try(:street)].compact.join(" ").presence
+        hackathon.street = [result.house_number, result.street].compact.join(" ").presence
       end
     end
 

--- a/app/models/hackathon/regional.rb
+++ b/app/models/hackathon/regional.rb
@@ -10,7 +10,7 @@ module Hackathon::Regional
         hackathon.province = result.province || result.state
         hackathon.city = result.city
         hackathon.address = result.address
-        hackathon.street = [result.house_number, result.street].compact.join(" ")
+        hackathon.street = [result.try(:house_number), result.try(:street)].compact.join(" ").presence
       end
     end
 
@@ -23,5 +23,9 @@ module Hackathon::Regional
 
   def general_location
     [city, province, country_code].compact.join(", ")
+  end
+
+  def to_location
+    Location.new(city, province, country_code)
   end
 end

--- a/app/models/hackathon/scheduled.rb
+++ b/app/models/hackathon/scheduled.rb
@@ -7,5 +7,7 @@ module Hackathon::Scheduled
     validate do
       errors.add(:ends_at, :before_start_date) if errors.none? && ends_at < starts_at
     end
+
+    scope :upcoming, -> { where("starts_at > ?", Time.now) }
   end
 end

--- a/app/models/hackathon/subscription.rb
+++ b/app/models/hackathon/subscription.rb
@@ -6,4 +6,5 @@ class Hackathon::Subscription < ApplicationRecord
   include Regional # depends on Status
 
   belongs_to :subscriber, class_name: "User", default: -> { Current.user }
+  has_many :listings, class_name: "Hackathon::Digest::Listing"
 end

--- a/app/models/hackathon/subscription/regional.rb
+++ b/app/models/hackathon/subscription/regional.rb
@@ -23,6 +23,10 @@ module Hackathon::Subscription::Regional
     location_input || [city, province, country_code].compact.join(", ")
   end
 
+  def to_location
+    Location.new(city, province, country_code)
+  end
+
   private
 
   def geocoding_needed?

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,9 +7,10 @@ class Location
 
   attr_reader :city, :province, :country
 
+  # Listed in the order of significance.
   # The name "component" is pulled from USPS
   # https://pe.usps.com/text/pub28/28c2_012.htm#ep526349
-  COMPONENTS_ORDERED_BY_SPECIFICITY = [:city, :province, :country]
+  COMPONENTS = [:city, :province, :country]
 
   def component(compon)
     send(compon) if compon.in? COMPONENTS

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -7,10 +7,9 @@ class Location
 
   attr_reader :city, :province, :country
 
-  # Listed in the order of significance.
   # The name "component" is pulled from USPS
   # https://pe.usps.com/text/pub28/28c2_012.htm#ep526349
-  COMPONENTS = [:city, :province, :country]
+  COMPONENTS_ORDERED_BY_SPECIFICITY = [:city, :province, :country]
 
   def component(compon)
     send(compon) if compon.in? COMPONENTS

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -37,10 +37,10 @@ class Location
   def covers?(other)
     # Location A covers location B if location A is the more broad than location B.
 
-    return false unless sig_component_value && other.send(:sig_component_value)
-    return false if sig_component_value >= other.send(:sig_component_value) # Location A is more specific than location B.
+    return false unless most_significant_component_value && other.most_significant_component_value
+    return false if most_significant_component_value >= other.most_significant_component_value # Location A is more specific than location B.
 
-    sig = other.send(:sig_component_value)
+    sig = other.most_significant_component_value
     COMPONENTS[sig..].all? do |compon|
       component(compon) == other.component(compon)
     end
@@ -62,9 +62,12 @@ class Location
     components.compact.join(", ")
   end
 
-  private
+  protected
 
-  def sig_component_value
+  # "Most Significant Component" value. Components with a higher significance
+  # have a higher value. This is useful for comparing the significance of two
+  # components.
+  def most_significant_component_value
     COMPONENTS.reverse.index most_significant_component
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,0 +1,68 @@
+class Location
+  def initialize(city, province, country)
+    @city = city
+    @province = province
+    @country = country
+  end
+
+  attr_reader :city, :province, :country
+
+  # Listed in the order of significance.
+  # The name "component" is pulled from USPS
+  # https://pe.usps.com/text/pub28/28c2_012.htm#ep526349
+  COMPONENTS = [:city, :province, :country]
+
+  def component(compon)
+    send(compon) if compon.in? COMPONENTS
+  end
+
+  def components
+    [@city, @province, @country]
+  end
+
+  def sig_component
+    # The significant component represents the most specific location attribute
+    # that is provided (similar to sig figs in math).
+    COMPONENTS.each do |compon|
+      return compon if send(compon).present?
+    end
+  end
+
+  def ==(other)
+    components == other.components
+  end
+
+  def covers?(other)
+    # Location A covers location B if location A is the more broad than location B.
+
+    return false unless sig_component_value && other.send(:sig_component_value)
+    return false if sig_component_value >= other.send(:sig_component_value) # Location A is more specific than location B.
+
+    sig = other.send(:sig_component_value)
+    COMPONENTS[sig..].all? do |compon|
+      component(compon) == other.component(compon)
+    end
+  end
+
+  def covers_or_equal?(other)
+    self == other || covers?(other)
+  end
+
+  def covered_by?(other)
+    other.covers?(self)
+  end
+
+  def covered_by_or_equal?(other)
+    self == other || covered_by?(other)
+  end
+
+  def to_s
+    components.compact.join(", ")
+  end
+
+  private
+
+  def sig_component_value
+    COMPONENTS.reverse.index sig_component
+  end
+end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,9 +20,11 @@ class Location
     [@city, @province, @country]
   end
 
-  def sig_component
-    # The significant component represents the most specific location attribute
-    # that is provided (similar to sig figs in math).
+  def most_significant_component
+    # The "most significant component" represents the most specific location
+    # attribute that is provided. This is similar to the concept of "most
+    # significant bit". With a full location (all attributes provided), the most
+    # significant component is the city.
     COMPONENTS.each do |compon|
       return compon if send(compon).present?
     end
@@ -63,6 +65,6 @@ class Location
   private
 
   def sig_component_value
-    COMPONENTS.reverse.index sig_component
+    COMPONENTS.reverse.index most_significant_component
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
   include Identifiable
   include Named
   include Privileged # depends on Eventable
+
+  has_many :subscriptions, class_name: "Hackathon::Subscription", foreign_key: "subscriber_id", inverse_of: :subscriber, dependent: :destroy
 end

--- a/db/migrate/20230726064503_add_belongs_to_subscription_on_hackathon_digest_lisings.rb
+++ b/db/migrate/20230726064503_add_belongs_to_subscription_on_hackathon_digest_lisings.rb
@@ -1,0 +1,5 @@
+class AddBelongsToSubscriptionOnHackathonDigestLisings < ActiveRecord::Migration[7.0]
+  def change
+    add_belongs_to :hackathon_digest_listings, :subscription, null: false, foreign_key: {to_table: :hackathon_subscriptions}
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_07_20_205641) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_26_064503) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -71,8 +71,10 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_205641) do
     t.bigint "hackathon_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "subscription_id", null: false
     t.index ["digest_id"], name: "index_hackathon_digest_listings_on_digest_id"
     t.index ["hackathon_id"], name: "index_hackathon_digest_listings_on_hackathon_id"
+    t.index ["subscription_id"], name: "index_hackathon_digest_listings_on_subscription_id"
   end
 
   create_table "hackathon_digests", force: :cascade do |t|
@@ -198,6 +200,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_07_20_205641) do
   add_foreign_key "events", "users", column: "creator_id"
   add_foreign_key "events", "users", column: "target_id"
   add_foreign_key "hackathon_digest_listings", "hackathon_digests", column: "digest_id"
+  add_foreign_key "hackathon_digest_listings", "hackathon_subscriptions", column: "subscription_id"
   add_foreign_key "hackathon_digest_listings", "hackathons"
   add_foreign_key "hackathon_digests", "users", column: "recipient_id"
   add_foreign_key "hackathon_subscriptions", "users", column: "subscriber_id"

--- a/test/fixtures/hackathons.yml
+++ b/test/fixtures/hackathons.yml
@@ -48,3 +48,5 @@ bellevue_hacks:
   city: Bellevue
   province: Washington
   country_code: US
+  latitude: 47.6144219
+  longitude: -122.192337

--- a/test/fixtures/hackathons.yml
+++ b/test/fixtures/hackathons.yml
@@ -1,5 +1,6 @@
 assemble:
   name: Assemble
+  status: <%= Hackathon.statuses[:approved] %>
   starts_at: August 5th, 2023
   ends_at: August 7th, 2023
   website: https://assemble.hackclub.com
@@ -8,3 +9,42 @@ assemble:
   modality: <%= Hackathon.modalities[:in_person] %>
   financial_assistance: true
   applicant: gary
+zephyr:
+  name: The Hacker Zephyr
+  status: <%= Hackathon.statuses[:approved] %>
+  starts_at: July 15th, 2023
+  ends_at: July 25th, 2023
+  website: https://zephyr.hackclub.com
+  high_school_led: true
+  expected_attendees: 50
+  modality: <%= Hackathon.modalities[:in_person] %>
+  financial_assistance: true
+  applicant: gary
+seattle_hacks:
+  name: SeattleHacks
+  status: <%= Hackathon.statuses[:approved] %>
+  starts_at: <%= 1.day.from_now %>
+  ends_at: <%= 2.days.from_now %>
+  website: https://hackclub.com
+  high_school_led: true
+  expected_attendees: 50
+  modality: <%= Hackathon.modalities[:in_person] %>
+  financial_assistance: true
+  applicant: gary
+  city: Seattle
+  province: Washington
+  country_code: US
+bellevue_hacks:
+  name: BellevueHacks
+  status: <%= Hackathon.statuses[:approved] %>
+  starts_at: <%= 1.day.from_now %>
+  ends_at: <%= 2.days.from_now %>
+  website: https://hackclub.com
+  high_school_led: true
+  expected_attendees: 50
+  modality: <%= Hackathon.modalities[:in_person] %>
+  financial_assistance: true
+  applicant: gary
+  city: Bellevue
+  province: Washington
+  country_code: US

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -76,7 +76,7 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
     assert_includes digest.listed_hackathons, hackathon_in_washington
   end
 
-  test "returns hackathon in the same subscription country" do
+  test "listing hackathons in the same country" do
     @user.subscriptions.create! location_input: "US"
 
     hackathon_in_us = hackathons(:seattle_hacks)

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -53,7 +53,7 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
     assert_includes digest.listed_hackathons, hackathon_in_seattle
   end
 
-  test "it returns hackathon within 150 miles of the subscription city" do
+  test "listing hackathons within 150 miles of a city" do
     @user.subscriptions.create! location_input: "Seattle, Washington, US"
 
     hackathon_near_seattle = hackathons(:bellevue_hacks).dup

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -67,7 +67,7 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
     assert_includes digest.listed_hackathons, hackathon_near_seattle
   end
 
-  test "returns hackathon in the same subscription state" do
+  test "listing hackathons in the same state" do
     @user.subscriptions.create! location_input: "Washington, US"
 
     hackathon_in_washington = hackathons(:seattle_hacks)

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+
+class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
+  setup do
+    seattle = {
+      "city" => "Seattle",
+      "state" => "Washington",
+      "country_code" => "us",
+      "coordinates" => [47.6038321, -122.330062]
+    }
+    Geocoder::Lookup::Test.add_stub("Seattle, Washington, US", [seattle])
+    Geocoder::Lookup::Test.add_stub(seattle["coordinates"], [seattle.except("coordinates")])
+
+    washington = {
+      "state" => "Washington",
+      "country_code" => "us",
+      "coordinates" => [47.2868352, -120.212613]
+    }
+    Geocoder::Lookup::Test.add_stub("Washington, US", [washington])
+    Geocoder::Lookup::Test.add_stub(washington["coordinates"], [washington.except("coordinates")])
+
+    us = {
+      "country_code" => "us",
+      "coordinates" => [39.7837304, -100.445882]
+    }
+    Geocoder::Lookup::Test.add_stub("US", [us])
+    Geocoder::Lookup::Test.add_stub(us["coordinates"], [us.except("coordinates")])
+
+    bellevue_wa = {
+      "city" => "Bellevue",
+      "state" => "Washington",
+      "country_code" => "us",
+      "coordinates" => [47.6144219, -122.192337]
+    }
+    Geocoder::Lookup::Test.add_stub("Bellevue, Washington, US", [bellevue_wa])
+    Geocoder::Lookup::Test.add_stub(bellevue_wa["coordinates"], [bellevue_wa.except("coordinates")])
+
+    @user = users(:gary)
+  end
+
+  test "when the user has no subscriptions it returns an empty array" do
+    digest = Hackathon::Digest.create! recipient: @user
+
+    assert_equal [], digest.listings
+  end
+
+  test "it returns hackathons in the same subscription city" do
+    @user.subscriptions.create! location_input: "Seattle, Washington, US"
+
+    hackathon_in_seattle = hackathons(:seattle_hacks)
+    digest = Hackathon::Digest.create! recipient: @user
+
+    assert_includes digest.listed_hackathons, hackathon_in_seattle
+  end
+
+  test "it returns hackathon within 150 miles of the subscription city" do
+    @user.subscriptions.create! location_input: "Seattle, Washington, US"
+
+    hackathon_near_seattle = hackathons(:bellevue_hacks).dup
+    hackathon_near_seattle.assign_attributes(
+      logo: active_storage_blobs(:assemble_logo), banner: active_storage_blobs(:assemble)
+    )
+    hackathon_near_seattle.save!
+
+    digest = Hackathon::Digest.create! recipient: @user
+
+    assert_includes digest.listed_hackathons, hackathon_near_seattle
+  end
+
+  test "returns hackathon in the same subscription state" do
+    @user.subscriptions.create! location_input: "Washington, US"
+
+    hackathon_in_washington = hackathons(:seattle_hacks)
+    digest = Hackathon::Digest.create! recipient: @user
+
+    assert_includes digest.listed_hackathons, hackathon_in_washington
+  end
+
+  test "returns hackathon in the same subscription country" do
+    @user.subscriptions.create! location_input: "US"
+
+    hackathon_in_us = hackathons(:seattle_hacks)
+    digest = Hackathon::Digest.create! recipient: @user
+
+    assert_includes digest.listed_hackathons, hackathon_in_us
+  end
+end

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -38,7 +38,7 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
     @user = users(:gary)
   end
 
-  test "when the user has no subscriptions it returns an empty array" do
+  test "creating a digest for user without subscriptions" do
     digest = Hackathon::Digest.create! recipient: @user
 
     assert_equal [], digest.listings

--- a/test/models/hackathon/digest/listings/by_location_test.rb
+++ b/test/models/hackathon/digest/listings/by_location_test.rb
@@ -26,15 +26,6 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
     Geocoder::Lookup::Test.add_stub("US", [us])
     Geocoder::Lookup::Test.add_stub(us["coordinates"], [us.except("coordinates")])
 
-    bellevue_wa = {
-      "city" => "Bellevue",
-      "state" => "Washington",
-      "country_code" => "us",
-      "coordinates" => [47.6144219, -122.192337]
-    }
-    Geocoder::Lookup::Test.add_stub("Bellevue, Washington, US", [bellevue_wa])
-    Geocoder::Lookup::Test.add_stub(bellevue_wa["coordinates"], [bellevue_wa.except("coordinates")])
-
     @user = users(:gary)
   end
 
@@ -56,11 +47,7 @@ class Hackathon::Digest::Listings::ByLocationTest < ActiveSupport::TestCase
   test "listing hackathons within 150 miles of a city" do
     @user.subscriptions.create! location_input: "Seattle, Washington, US"
 
-    hackathon_near_seattle = hackathons(:bellevue_hacks).dup
-    hackathon_near_seattle.assign_attributes(
-      logo: active_storage_blobs(:assemble_logo), banner: active_storage_blobs(:assemble)
-    )
-    hackathon_near_seattle.save!
+    hackathon_near_seattle = hackathons(:bellevue_hacks)
 
     digest = Hackathon::Digest.create! recipient: @user
 

--- a/test/models/hackathon/regional_test.rb
+++ b/test/models/hackathon/regional_test.rb
@@ -36,7 +36,7 @@ class Hackathon::RegionalTest < ActiveSupport::TestCase
           "city" => "Shelburne",
           "state" => "Vermont",
           "postal_code" => "05482",
-          "country_code" => "US"
+          "country_code" => "us"
         }
       ]
     )
@@ -60,7 +60,7 @@ class Hackathon::RegionalTest < ActiveSupport::TestCase
           "city" => "Shelburne",
           "state" => "Vermont",
           "postal_code" => "05482",
-          "country_code" => "US"
+          "country_code" => "us"
         }
       ]
     )

--- a/test/models/hackathon/subscription_test.rb
+++ b/test/models/hackathon/subscription_test.rb
@@ -11,7 +11,7 @@ class SubscriptionTest < ActiveSupport::TestCase
         {
           "city" => "Shelburne",
           "state" => "Vermont",
-          "country_code" => "US"
+          "country_code" => "us"
         }
       ]
     )

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -14,7 +14,7 @@ class LocationTest < ActiveSupport::TestCase
 
     assert_equal %w[Seattle Washington US], loc.components
 
-    assert :city, loc.sig_component
+    assert :city, loc.most_significant_component
   end
 
   test "creating a location without city" do
@@ -30,7 +30,7 @@ class LocationTest < ActiveSupport::TestCase
 
     assert_equal [nil, "Washington", "US"], loc.components
 
-    assert :province, loc.sig_component
+    assert :province, loc.most_significant_component
   end
 
   test "creating a location without province" do
@@ -46,7 +46,7 @@ class LocationTest < ActiveSupport::TestCase
 
     assert_equal ["Seattle", nil, "US"], loc.components
 
-    assert :city, loc.sig_component
+    assert :city, loc.most_significant_component
   end
 
   test "creating a location without city and province" do
@@ -62,7 +62,7 @@ class LocationTest < ActiveSupport::TestCase
 
     assert_equal [nil, nil, "US"], loc.components
 
-    assert :country, loc.sig_component
+    assert :country, loc.most_significant_component
   end
 
   test "country covers city" do

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -1,0 +1,136 @@
+require "test_helper"
+
+class LocationTest < ActiveSupport::TestCase
+  test "creating a location" do
+    loc = Location.new("Seattle", "Washington", "US")
+
+    assert_equal "Seattle", loc.city
+    assert_equal "Washington", loc.province
+    assert_equal "US", loc.country
+
+    assert_equal "Seattle", loc.component(:city)
+    assert_equal "Washington", loc.component(:province)
+    assert_equal "US", loc.component(:country)
+
+    assert_equal %w[Seattle Washington US], loc.components
+
+    assert :city, loc.sig_component
+  end
+
+  test "creating a location without city" do
+    loc = Location.new(nil, "Washington", "US")
+
+    assert_nil loc.city
+    assert_equal "Washington", loc.province
+    assert_equal "US", loc.country
+
+    assert_nil loc.component(:city)
+    assert_equal "Washington", loc.component(:province)
+    assert_equal "US", loc.component(:country)
+
+    assert_equal [nil, "Washington", "US"], loc.components
+
+    assert :province, loc.sig_component
+  end
+
+  test "creating a location without province" do
+    loc = Location.new("Seattle", nil, "US")
+
+    assert_equal "Seattle", loc.city
+    assert_nil loc.province
+    assert_equal "US", loc.country
+
+    assert_equal "Seattle", loc.component(:city)
+    assert_nil loc.component(:province)
+    assert_equal "US", loc.component(:country)
+
+    assert_equal ["Seattle", nil, "US"], loc.components
+
+    assert :city, loc.sig_component
+  end
+
+  test "creating a location without city and province" do
+    loc = Location.new(nil, nil, "US")
+
+    assert_nil loc.city
+    assert_nil loc.province
+    assert_equal "US", loc.country
+
+    assert_nil loc.component(:city)
+    assert_nil loc.component(:province)
+    assert_equal "US", loc.component(:country)
+
+    assert_equal [nil, nil, "US"], loc.components
+
+    assert :country, loc.sig_component
+  end
+
+  test "country covers city" do
+    seattle = Location.new("Seattle", "Washington", "US")
+    us = Location.new(nil, nil, "US")
+
+    assert us.covers? seattle
+    assert seattle.covered_by? us
+    assert_not seattle == us
+  end
+
+  test "state covers city" do
+    seattle = Location.new("Seattle", "Washington", "US")
+    wa = Location.new(nil, "Washington", "US")
+
+    assert wa.covers? seattle
+    assert seattle.covered_by? wa
+    assert_not seattle == wa
+  end
+
+  test "city equals city" do
+    seattle1 = Location.new("Seattle", "Washington", "US")
+    seattle2 = seattle1.dup
+
+    assert seattle1 == seattle2
+    assert seattle2 == seattle1
+
+    assert seattle1.covers_or_equal? seattle2
+    assert seattle2.covers_or_equal? seattle1
+
+    assert_not seattle1.covers? seattle2
+    assert_not seattle2.covers? seattle1
+
+    assert_not seattle1.covered_by? seattle2
+    assert_not seattle2.covered_by? seattle1
+  end
+
+  test "state equals state" do
+    wa1 = Location.new(nil, "Washington", "US")
+    wa2 = wa1.dup
+
+    assert wa1 == wa2
+    assert wa2 == wa1
+
+    assert wa1.covers_or_equal? wa2
+    assert wa2.covers_or_equal? wa1
+
+    assert_not wa1.covers? wa2
+    assert_not wa2.covers? wa1
+
+    assert_not wa1.covered_by? wa2
+    assert_not wa2.covered_by? wa1
+  end
+
+  test "country equals country" do
+    us1 = Location.new(nil, nil, "US")
+    us2 = us1.dup
+
+    assert us1 == us2
+    assert us2 == us1
+
+    assert us1.covers_or_equal? us2
+    assert us2.covers_or_equal? us1
+
+    assert_not us1.covers? us2
+    assert_not us2.covers? us1
+
+    assert_not us1.covered_by? us2
+    assert_not us2.covered_by? us1
+  end
+end


### PR DESCRIPTION
This PR contains working logic for building Digest Listings. Here's a very rough run down on how it works:
- If a Hackathon's location exactly matches a Subscription's location, it is included.
- Subscriptions that have a "significant component" of `city` will use coordinate distance. Anything within 150 miles will be included
	- "significant component" is similar to the concept of sig figs in math
	- See the `Location` PORO model for more info.