### PR TITLE
Refactor and clean up `Location`

### DIFF
--- a/app/models/hackathon/digest/listings/criterion/location.rb
+++ b/app/models/hackathon/digest/listings/criterion/location.rb
@@ -34,7 +34,7 @@ module Hackathon::Digest::Listings
       # significant component of city).
       #
       # Highly recommended video 📺: https://www.youtube.com/watch?v=vh6zanS_epw
-      return [] unless location.most_significant_component == :city
+      return [] unless location.city_most_significant?
 
       upcoming_hackathons
         .where.not(city: [nil, ""]) # where Most Significant Component is city

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -12,10 +12,6 @@ class Location
   # https://pe.usps.com/text/pub28/28c2_012.htm#ep526349
   COMPONENTS = [:city, :province, :country]
 
-  def component(compon)
-    send(compon) if compon.in? COMPONENTS
-  end
-
   def components
     [@city, @province, @country]
   end
@@ -52,7 +48,7 @@ class Location
 
     sig = other.most_significant_component_value
     COMPONENTS[sig..].all? do |compon|
-      component(compon) == other.component(compon)
+      send(compon) == other.send(compon)
     end
   end
 

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -1,8 +1,8 @@
 class Location
-  def initialize(city, province, country)
+  def initialize(city, province, country_code)
     @city = city
     @province = province
-    @country = country
+    @country = country_code
   end
 
   attr_reader :city, :province, :country
@@ -17,7 +17,8 @@ class Location
   end
 
   def country_name
-    ISO3166::Country[@country]&.common_name
+    (ISO3166::Country[@country] || ISO3166::Country.find_country_by_any_name(@country))
+      &.common_name
   end
 
   def most_significant_component

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -30,6 +30,12 @@ class Location
     end
   end
 
+  COMPONENTS.each do |compon|
+    define_method "#{compon}_most_significant?" do
+      most_significant_component == compon
+    end
+  end
+
   def ==(other)
     components == other.components
   end
@@ -63,12 +69,9 @@ class Location
   end
 
   def to_formatted_s(format = nil)
-    case format
-    when :short
-      (@country == "US") ? [city, province].compact.join(", ") : to_s
-    else
-      to_s
-    end
+    return to_s unless format == :short && @country == "US" && !country_most_significant?
+
+    [city, province].compact.join(", ")
   end
 
   alias_method :to_fs, :to_formatted_s

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -20,6 +20,10 @@ class Location
     [@city, @province, @country]
   end
 
+  def country_name
+    ISO3166::Country[@country]&.common_name
+  end
+
   def most_significant_component
     # The "most significant component" represents the most specific location
     # attribute that is provided. This is similar to the concept of "most
@@ -65,6 +69,8 @@ class Location
   end
 
   def to_s
+    return country_name if country_most_significant? && country_name.present?
+
     components.compact.join(", ")
   end
 

--- a/app/views/hackathons/digest_mailer/_subscription.html.erb
+++ b/app/views/hackathons/digest_mailer/_subscription.html.erb
@@ -1,5 +1,8 @@
 <h2>
-  <span style="font-weight: lighter">Near</span> <%= subscription.to_location.to_fs(:short) %>
+  <span style="font-weight: lighter">
+    <%= subscription.to_location.city_most_significant? ? "Near" : "In" %>
+  </span>
+  <%= subscription.to_location.to_fs(:short) %>
 </h2>
 <div style="margin-bottom: 2rem;">
   <% listings.each do |listing| %>

--- a/app/views/hackathons/digest_mailer/_subscription.text.erb
+++ b/app/views/hackathons/digest_mailer/_subscription.text.erb
@@ -1,4 +1,4 @@
-Near <%= subscription.to_location.to_fs(:short) %>
+<%= subscription.to_location.city_most_significant? ? "Near" : "In" %> <%= subscription.to_location.to_fs(:short) %>
 
 <% listings.each do |listing| %>
   <%= render "hackathon", hackathon: listing.hackathon %>

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -8,10 +8,6 @@ class LocationTest < ActiveSupport::TestCase
     assert_equal "Washington", loc.province
     assert_equal "US", loc.country
 
-    assert_equal "Seattle", loc.component(:city)
-    assert_equal "Washington", loc.component(:province)
-    assert_equal "US", loc.component(:country)
-
     assert_equal %w[Seattle Washington US], loc.components
 
     assert :city, loc.most_significant_component
@@ -23,10 +19,6 @@ class LocationTest < ActiveSupport::TestCase
     assert_nil loc.city
     assert_equal "Washington", loc.province
     assert_equal "US", loc.country
-
-    assert_nil loc.component(:city)
-    assert_equal "Washington", loc.component(:province)
-    assert_equal "US", loc.component(:country)
 
     assert_equal [nil, "Washington", "US"], loc.components
 
@@ -40,10 +32,6 @@ class LocationTest < ActiveSupport::TestCase
     assert_nil loc.province
     assert_equal "US", loc.country
 
-    assert_equal "Seattle", loc.component(:city)
-    assert_nil loc.component(:province)
-    assert_equal "US", loc.component(:country)
-
     assert_equal ["Seattle", nil, "US"], loc.components
 
     assert :city, loc.most_significant_component
@@ -55,10 +43,6 @@ class LocationTest < ActiveSupport::TestCase
     assert_nil loc.city
     assert_nil loc.province
     assert_equal "US", loc.country
-
-    assert_nil loc.component(:city)
-    assert_nil loc.component(:province)
-    assert_equal "US", loc.component(:country)
 
     assert_equal [nil, nil, "US"], loc.components
 

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -117,4 +117,42 @@ class LocationTest < ActiveSupport::TestCase
     assert_not us1.covered_by? us2
     assert_not us2.covered_by? us1
   end
+
+  test "country to country name" do
+    location = Location.new(nil, nil, "US")
+    assert_equal "United States", location.country_name
+
+    location = Location.new(nil, nil, "United States")
+    assert_equal "United States", location.country_name
+  end
+
+  test "non-existent country code to country name" do
+    location = Location.new(nil, nil, nil)
+    assert_equal nil, location.country_name
+
+    location = Location.new(nil, nil, "I DON'T EXIST")
+    assert_equal nil, location.country_name
+  end
+
+  test "to_s with only country" do
+    location = Location.new(nil, nil, "US")
+
+    # Should use country's common name
+    assert_equal "United States", location.to_s
+  end
+
+  test "to_s with short format" do
+    location = Location.new("Seattle", "Washington", "US")
+    assert_equal "Seattle, Washington", location.to_formatted_s(:short) # Should drop the country if in the US
+
+    # to_formatted_s and to_s should be the same
+    location = Location.new("Vancouver", "British Columbia", "CA")
+    assert_equal "Vancouver, British Columbia, CA", location.to_fs(:short)
+  end
+
+  test "short to_s, with only country" do
+    location = Location.new(nil, nil, "US")
+    # Should use country's common name
+    assert_equal "United States", location.to_fs(:short)
+  end
 end


### PR DESCRIPTION
Also, the Hackathon Digest mailer now says "_In_ country", rather than "_Near_ country". It'll still say "Near" for cities, but use "In" for states and countries.

![image](https://github.com/hackclub/hackathons-backend/assets/20099646/3b3d3a64-ead8-4b66-b376-b01b457ce127)
![image](https://github.com/hackclub/hackathons-backend/assets/20099646/ea7cca50-f6dd-418a-86a0-610670b897bd)
