### PR TITLE
Fix bug on filter overlapping subscriptions

### DIFF
--- a/app/models/hackathon/digest/listings/criterion/location.rb
+++ b/app/models/hackathon/digest/listings/criterion/location.rb
@@ -51,7 +51,7 @@ module Hackathon::Digest::Listings
         # For example, "Seattle, WA, US" would be covered by a subscription to
         # "WA US" (which is more general than Seattle).
         active_subscriptions.any? do |other|
-          subscription.to_location.covers?(other.to_location)
+          subscription.to_location.covered_by?(other.to_location)
         end
       end
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,7 +47,7 @@ class Location
     return false unless most_significant_component_value && other.most_significant_component_value
     return false if most_significant_component_value >= other.most_significant_component_value # Location A is more specific than location B.
 
-    sig = other.most_significant_component_value
+    sig = COMPONENTS.index most_significant_component
     COMPONENTS[sig..].all? do |compon|
       send(compon) == other.send(compon)
     end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -47,6 +47,14 @@ class Location
     return false unless most_significant_component_value && other.most_significant_component_value
     return false if most_significant_component_value >= other.most_significant_component_value # Location A is more specific than location B.
 
+    # Loops from this object's most significant component to it's least
+    # significant component.
+    #   Example:
+    #   - If MSC is city, then loop from          city -> province -> country
+    #   - If MSC is province, then loop from      province -> country
+    #   - If MSC is country, then loop through    country
+    # For each iteration, check that each component is equal to the other
+    # object's component.
     sig = COMPONENTS.index most_significant_component
     COMPONENTS[sig..].all? do |compon|
       send(compon) == other.send(compon)

--- a/test/models/hackathon/digest/listings/criterion/location_test.rb
+++ b/test/models/hackathon/digest/listings/criterion/location_test.rb
@@ -2,26 +2,48 @@ require "test_helper"
 
 class Hackathon::Digest::Listings::Criterion::LocationTest < ActiveSupport::TestCase
   setup do
-    seattle = {
+    Geocoder::Lookup::Test.add_stub("Seattle, Washington, US", [{
       city: "Seattle",
       state: "Washington",
       country_code: "us",
       coordinates: [47.6038321, -122.330062]
-    }
-    Geocoder::Lookup::Test.add_stub("Seattle, Washington, US", [seattle])
+    }])
 
-    washington = {
+    Geocoder::Lookup::Test.add_stub("Bellevue, Washington, US", [{
+      city: "Bellevue",
+      state: "Washington",
+      country_code: "us",
+      coordinates: [47.6144219, -122.192337]
+    }])
+
+    Geocoder::Lookup::Test.add_stub("Redmond, Washington, US", [{
+      city: "Redmond",
+      state: "Washington",
+      country_code: "us",
+      coordinates: [46.6988644, -120.4409335]
+    }])
+
+    Geocoder::Lookup::Test.add_stub("Washington, US", [{
       state: "Washington",
       country_code: "us",
       coordinates: [47.2868352, -120.212613]
-    }
-    Geocoder::Lookup::Test.add_stub("Washington, US", [washington])
+    }])
 
-    us = {
+    Geocoder::Lookup::Test.add_stub("California, US", [{
+      state: "California",
+      country_code: "us",
+      coordinates: [36.7014631, -118.755997]
+    }])
+
+    Geocoder::Lookup::Test.add_stub("US", [{
       country_code: "us",
       coordinates: [39.7837304, -100.445882]
-    }
-    Geocoder::Lookup::Test.add_stub("US", [us])
+    }])
+
+    Geocoder::Lookup::Test.add_stub("Canada", [{
+      country_code: "ca",
+      coordinates: [61.0666922, -107.991707]
+    }])
 
     @user = users(:gary)
   end
@@ -63,5 +85,68 @@ class Hackathon::Digest::Listings::Criterion::LocationTest < ActiveSupport::Test
     digest = Hackathon::Digest.create! recipient: @user
 
     assert_includes digest.listed_hackathons, hackathon_in_us
+  end
+
+  test "US makes Seattle redundant" do
+    # If there's a subscription to "US", then we don't need "Seattle, WA, US
+    seattle = hackathon_subscriptions(:gary_seattle)
+    us = @user.subscriptions.create! location_input: "US"
+
+    location_criterion = Hackathon::Digest::Listings::Criterion::Location.new(recipient: @user)
+    subscriptions = location_criterion.send(:subscriptions_to_search)
+
+    assert_not_includes subscriptions, seattle
+    assert_includes subscriptions, us
+  end
+
+  test "Washington makes Seattle redundant" do
+    # If there's a subscription to "Washington, US", then we don't need "Seattle, WA, US"
+    seattle = hackathon_subscriptions(:gary_seattle)
+    washington = @user.subscriptions.create! location_input: "Washington, US"
+
+    location_criterion = Hackathon::Digest::Listings::Criterion::Location.new(recipient: @user)
+    subscriptions = location_criterion.send(:subscriptions_to_search)
+
+    assert_not_includes subscriptions, seattle
+    assert_includes subscriptions, washington
+  end
+
+  test "keeps subscriptions of same location significance (city)" do
+    user = User.create!(name: "User without subscriptions", email_address: "no@subscriptions.test")
+
+    bellevue = user.subscriptions.create! location_input: "Bellevue, Washington, US"
+    redmond = user.subscriptions.create! location_input: "Redmond, Washington, US"
+
+    location_criterion = Hackathon::Digest::Listings::Criterion::Location.new(recipient: user)
+    subscriptions = location_criterion.send(:subscriptions_to_search)
+
+    assert_includes subscriptions, bellevue
+    assert_includes subscriptions, redmond
+  end
+
+  test "keeps subscriptions of same location significance (state)" do
+    user = User.create!(name: "User without subscriptions", email_address: "no@subscriptions.test")
+
+    washington = user.subscriptions.create! location_input: "Washington, US"
+    california = user.subscriptions.create! location_input: "California, US"
+
+    location_criterion = Hackathon::Digest::Listings::Criterion::Location.new(recipient: user)
+    subscriptions = location_criterion.send(:subscriptions_to_search)
+
+    assert_includes subscriptions, washington
+    assert_includes subscriptions, california
+  end
+
+  test "keeps subscriptions of same location significance (country)" do
+    user = User.create!(name: "User without subscriptions", email_address: "no@subscriptions.test")
+
+    us = user.subscriptions.create! location_input: "US"
+    canada = user.subscriptions.create! location_input: "Canada"
+
+    location_criterion = Hackathon::Digest::Listings::Criterion::Location.new(recipient: user)
+    subscriptions = location_criterion.send(:subscriptions_to_search)
+
+    assert_includes subscriptions, us
+    assert_includes subscriptions, canada
   end
 end

--- a/test/models/location_test.rb
+++ b/test/models/location_test.rb
@@ -49,6 +49,15 @@ class LocationTest < ActiveSupport::TestCase
     assert :country, loc.most_significant_component
   end
 
+  test "country covers state" do
+    washington = Location.new(nil, "Washington", "US")
+    us = Location.new(nil, nil, "US")
+
+    assert us.covers? washington
+    assert washington.covered_by? us
+    assert_not washington == us
+  end
+
   test "country covers city" do
     seattle = Location.new("Seattle", "Washington", "US")
     us = Location.new(nil, nil, "US")


### PR DESCRIPTION
Fix a bug on filtering out overlapping subscriptions and add tests.

Previously, `US covers? Washington, US` would be false 🥲