### PR TITLE
Set UserMailer queue to `critical`

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -1,4 +1,6 @@
 class UserMailer < ApplicationMailer
+  self.deliver_later_queue_name = :critical
+
   before_action :set_user
 
   def authentication(authentication)


### PR DESCRIPTION
Under heavy job loads, this prioritizes sending user login emails

Ideally, I think we should be doing `deliver_now` rather than `deliver_later` for user logins