### PR TITLE
Make auth tokens unique and session tokens signed

### DIFF
--- a/app/controllers/concerns/authenticate.rb
+++ b/app/controllers/concerns/authenticate.rb
@@ -9,7 +9,7 @@ module Authenticate
   private
 
   def authenticate
-    if (session = User::Session.find_by(token: cookies.encrypted[:session_token]))
+    if (session = User::Session.find_by(token: cookies.signed[:session_token]))
       session.access
       Current.session = session
     end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -17,7 +17,7 @@ class Users::SessionsController < ApplicationController
       authentication.complete
       session = authentication.create_session!
 
-      cookies.encrypted[:session_token] = session.token
+      cookies.signed[:session_token] = session.token
       redirect_to root_path
     else
       redirect_to sign_in_path
@@ -26,7 +26,7 @@ class Users::SessionsController < ApplicationController
 
   def destroy
     Current.session.destroy!
-    cookies.encrypted[:session_token] = nil
+    cookies.signed[:session_token] = nil
     redirect_to root_path
   end
 end

--- a/db/migrate/20230815053636_make_auth_tokens_unique.rb
+++ b/db/migrate/20230815053636_make_auth_tokens_unique.rb
@@ -1,0 +1,8 @@
+class MakeAuthTokensUnique < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :user_authentications, :token
+    add_index :user_authentications, :token, unique: true
+    remove_index :user_sessions, :token
+    add_index :user_sessions, :token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_08_15_052624) do
+ActiveRecord::Schema[7.1].define(version: 2023_08_15_053636) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -174,7 +174,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_15_052624) do
     t.string "token", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["token"], name: "index_user_authentications_on_token"
+    t.index ["token"], name: "index_user_authentications_on_token", unique: true
     t.index ["user_id"], name: "index_user_authentications_on_user_id"
   end
 
@@ -185,7 +185,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_15_052624) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["authentication_id"], name: "index_user_sessions_on_authentication_id"
-    t.index ["token"], name: "index_user_sessions_on_token"
+    t.index ["token"], name: "index_user_sessions_on_token", unique: true
   end
 
   create_table "users", force: :cascade do |t|

--- a/lib/constraints/admin.rb
+++ b/lib/constraints/admin.rb
@@ -2,7 +2,7 @@ module Constraints
   class Admin
     def self.matches?(request)
       cookies = ActionDispatch::Cookies::CookieJar.build(request, request.cookies)
-      session = User::Session.find_by(token: cookies.encrypted[:session_token])
+      session = User::Session.find_by(token: cookies.signed[:session_token])
 
       session&.user&.admin?
     end


### PR DESCRIPTION
No need for encryption when it's already a secure token, and it could help with debugging. We don't have production sessions at this point so it won't have any impact.