### PR TITLE
Console1984: Ask for username (don't raise error)

### DIFF
--- a/config/initializers/console1984.rb
+++ b/config/initializers/console1984.rb
@@ -1,4 +1,5 @@
 Rails.application.configure do
+  config.console1984.ask_for_username_if_empty = true
   config.console1984.incinerate = false
   config.console1984.production_data_warning = <<~WARNING
     You have access to production data here. That's a big deal.


### PR DESCRIPTION
> If true, the console will ask for a username if it is empty. If false, it will raise an error if no username is set. Defaults to false.

https://github.com/basecamp/console1984#configuration