### PR TITLE
Install `lograge` to minimize log verbosity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem "audits1984"
 
 # Application monitoring (errors, performance, etc.)
 gem "appsignal"
+gem "lograge" # Log formatting
 
 group :development, :test do
   gem "debug", platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,6 +228,11 @@ GEM
       rexml
     lint_roller (1.1.0)
     local_time (2.1.0)
+    lograge (0.13.0)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -320,6 +325,8 @@ GEM
     regexp_parser (2.8.1)
     reline (0.3.7)
       io-console (~> 0.5)
+    request_store (1.5.1)
+      rack (>= 1.4)
     rexml (3.2.6)
     rinku (2.0.6)
     rouge (4.1.3)
@@ -452,6 +459,7 @@ DEPENDENCIES
   jbuilder
   letter_opener_web
   local_time
+  lograge
   mrsk
   pagy
   pg

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,12 +51,20 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Log to STDOUT and AppSignal.
+  # Use lograge to tame log output.
+  config.lograge.enabled = true
+
+  # Log to both STDOUT and AppSignal.
+  config.lograge.keep_original_rails_log = true
+  config.lograge.logger = Appsignal::Logger.new(
+    "rails",
+    format: Appsignal::Logger::LOGFMT
+  )
   console_logger = ActiveSupport::Logger.new($stdout)
     .tap { |logger| logger.formatter = ::Logger::Formatter.new }
     .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-  config.logger = console_logger.extend(
-    ActiveSupport::Logger.broadcast(ActiveSupport::TaggedLogging.new(Appsignal::Logger.new("rails")))
+  config.lograge.logger = console_logger.extend(
+    ActiveSupport::Logger.broadcast(Appsignal::Logger.new("rails", format: Appsignal::Logger::LOGFMT))
   )
 
   # Prepend all log lines with the following tags.


### PR DESCRIPTION
Also provides LOGFMT for AppSignal's log attributes

![image](https://github.com/hackclub/hackathons-backend/assets/20099646/20b4ae3e-a2d7-4dd1-be93-9a392597cb12)


https://docs.appsignal.com/logging/platforms/integrations/ruby.html#lograge