### PR TITLE
Deliver user auth mailers now (rather than later)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The thing that *soon* powers [hackathons.hackclub.com](https://hackathons.hackcl
    ```sh
    bundle exec sidekiq
    ```
-   Sidekiq is necessary for emails (such as sign in links) to be sent.
+   Sidekiq is necessary for most emails to be sent.
 
 The application will now be running at [localhost:3000](http://localhost:3000)!
 

--- a/app/models/user/authentication.rb
+++ b/app/models/user/authentication.rb
@@ -1,5 +1,6 @@
 class User::Authentication < ApplicationRecord
   include Deliverable
+  delivered :now
   include Eventable
 
   belongs_to :user


### PR DESCRIPTION
User auth mailers are critical and should not depend on having the background job server (Sidekiq) running

---

Also removes the `Deliverable#deliver_later` and `Deliverable#deliver_now` methods since they realistically will only be used by the callback and clutter the namespace