### PR TITLE
Rails schema autoformatting

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,11 +165,11 @@ ActiveRecord::Schema[7.1].define(version: 2023_08_15_205623) do
     t.string "street"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.bigint "applicant_id", null: false
     t.string "website"
     t.boolean "high_school_led", default: true, null: false
     t.integer "expected_attendees"
     t.integer "modality", default: 0, null: false
-    t.bigint "applicant_id", null: false
     t.bigint "swag_mailing_address_id"
     t.boolean "apac"
     t.string "airtable_id"


### PR DESCRIPTION
This likely got out of order due to merge conflicts.

@northeastprince if you're seeing this same change when running `bin/rails db:migrate` on `main`, then please go ahead and merge it!