### PR TITLE
Bring back sidekiq config

### DIFF
--- a/app/jobs/hackathons/config/sidekiq.yml
+++ b/app/jobs/hackathons/config/sidekiq.yml
@@ -1,0 +1,9 @@
+---
+:verbose: false
+:concurrency: 10
+:timeout: 25
+
+:queues:
+  - critical
+  - default
+  - low


### PR DESCRIPTION
Since we're still using Sidekiq in prod, we should bring back the config so that Sidekiq is aware of the `critical` and `low` queues (by default, it only knows the `default` queue)

https://github.com/sidekiq/sidekiq/wiki/Advanced-Options

The file was removed in https://github.com/hackclub/hackathons-backend/pull/150