### PR TITLE
Revert "Bump rails from `c0980d3` to `ccee593`"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: ccee593fed07cad128a54443b13af140b264c7c5
+  revision: c0980d30360149d0c77beb79850e047440c628bf
   specs:
     actioncable (7.1.0.alpha)
       actionpack (= 7.1.0.alpha)
@@ -327,7 +327,7 @@ GEM
     redis-client (0.15.0)
       connection_pool
     regexp_parser (2.8.1)
-    reline (0.3.8)
+    reline (0.3.7)
       io-console (~> 0.5)
     request_store (1.5.1)
       rack (>= 1.4)


### PR DESCRIPTION
Reverts hackclub/hackathons-backend#182

This update broke deploys