### PR TITLE
DigestMailer#admin_summary: Remove unused code

### DIFF
--- a/app/mailers/hackathons/digest_mailer.rb
+++ b/app/mailers/hackathons/digest_mailer.rb
@@ -14,8 +14,7 @@ class Hackathons::DigestMailer < ApplicationMailer
   def admin_summary(sent_digests)
     # This reloads the (possible) sent_digests array as an
     # ActiveRecord::Relation so that we can use includes to prevent an N+1.
-    @sent_digests = Hackathon::Digest.where(id: sent_digests.map(&:id)) ||
-      Hackathon::Digest.where(created_at: 6.days.ago...Time.now)
+    @sent_digests = Hackathon::Digest.where(id: sent_digests.map(&:id))
 
     @sent_digests_by_hackathons = @sent_digests
       .includes(listings: {hackathon: {logo_attachment: :blob}})

--- a/test/mailers/previews/hackathon/digest_mailer_preview.rb
+++ b/test/mailers/previews/hackathon/digest_mailer_preview.rb
@@ -5,6 +5,6 @@ class Hackathons::DigestMailerPreview < ActionMailer::Preview
   end
 
   def admin_summary
-    Hackathons::DigestMailer.with(digests: Hackathon::Digest.all).admin_summary
+    Hackathons::DigestMailer.admin_summary(Hackathon::Digest.all)
   end
 end


### PR DESCRIPTION
For important pieces of code (especially when notifying users), I'd rather be more explicit and remove assumptions. Rather than defaulting to digests sent in the past 6 days, we should require them to be passed in.

```ruby
digests = Hackathon::Digest.where(created_at: 6.days.ago...Time.now)
Hackathons::DigestMailer.admin_summary(digests).deliver_later
```

This helps prevent assumptions that may not hold true in future code changes.