### PR TITLE
Add 15-minute timeout for testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     services:
       postgres:
         image: postgres:15.3


### PR DESCRIPTION
Now if tests hang, it won't go on for way longer.