### PR TITLE
Just send lograge output to AppSignal

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -51,29 +51,15 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Use lograge to tame log output.
+  # Use lograge to tame log output to AppSignal.
   config.lograge.enabled = true
-
-  # Don't log health checks.
   config.lograge.ignore_actions = ["Rails::HealthController#show"]
-
-  # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]
-  config.lograge.custom_payload do |controller|
-    {request_id: controller.request.uuid}
-  end
-
-  # Log to both STDOUT and AppSignal.
+  config.lograge.custom_payload { |controller| {request_id: controller.request.uuid} }
   config.lograge.keep_original_rails_log = true
   config.lograge.logger = Appsignal::Logger.new(
     "rails",
     format: Appsignal::Logger::LOGFMT
-  )
-  console_logger = ActiveSupport::Logger.new($stdout)
-    .tap { |logger| logger.formatter = ::Logger::Formatter.new }
-    .then { |logger| ActiveSupport::TaggedLogging.new(logger) }
-  config.lograge.logger = console_logger.extend(
-    ActiveSupport::Logger.broadcast(Appsignal::Logger.new("rails", format: Appsignal::Logger::LOGFMT))
   )
 
   # Info include generic and useful information about system operation, but avoids logging too much


### PR DESCRIPTION
Lograge is great for most cases, but there are times when you might want more information - this sends lograge output to AppSignal but keeps the default, more detailed logging to `$stdout` that can be `grep`'d via `kamal app logs -g <request_id>`.