### PR TITLE
Remove unused hackathon name update action

### DIFF
--- a/app/controllers/admin/hackathons/names_controller.rb
+++ b/app/controllers/admin/hackathons/names_controller.rb
@@ -3,18 +3,4 @@ class Admin::Hackathons::NamesController < Admin::BaseController
 
   def edit
   end
-
-  def update
-    if @hackathon.update(hackathon_params)
-      redirect_to admin_hackathon_path(@hackathon)
-    else
-      render :edit, status: :unprocessable_entity
-    end
-  end
-
-  private
-
-  def hackathon_params
-    params.require(:hackathon).permit(:name)
-  end
 end


### PR DESCRIPTION
The hackathon attribute editing forms for admins just use the general hackathon update action, which works fine.