### PR TITLE
Set session_token cookies as Secure in production

### DIFF
--- a/app/controllers/concerns/authenticate.rb
+++ b/app/controllers/concerns/authenticate.rb
@@ -13,8 +13,8 @@ module Authenticate
       session.access
       Current.session = session
 
-      # handle cookies that weren't initially set as HTTP-only
-      cookies.permanent.signed[:session_token] = {value: cookies.permanent.signed[:session_token], httponly: true}
+      # handle cookies that weren't initially set as HTTP-only / Secure
+      cookies.permanent.signed[:session_token] = {value: cookies.signed[:session_token], httponly: true, secure: Rails.env.production?}
     end
   end
 

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -19,7 +19,8 @@ class Users::SessionsController < ApplicationController
     authentication.complete
     session = authentication.create_session!
 
-    cookies.permanent.signed[:session_token] = {value: session.token, httponly: true}
+    cookies.permanent.signed[:session_token] = {value: session.token, httponly: true, secure: Rails.env.production?}
+
     redirect_to hackathons_submissions_path
   end
 


### PR DESCRIPTION
This makes it so the cookie is only sent over HTTPS.