### PR TITLE
Don't require holding for review to approve/reject

### DIFF
--- a/app/views/admin/hackathons/show.html.erb
+++ b/app/views/admin/hackathons/show.html.erb
@@ -93,13 +93,9 @@
   </div>
 
   <div class="button-group">
-    <% if @hackathon.pending? %>
-      <%= button_to "Approve", admin_hackathon_approval_path(@hackathon), class: "button--success" %>
-      <%= button_to "Reject", admin_hackathon_rejection_path(@hackathon), class: "button--danger" %>
-    <% end %>
-    <% unless @hackathon.pending? %>
-      <%= button_to "Hold for review", admin_hackathon_hold_path(@hackathon), class: "button--neutral" %>
-    <% end %>
+    <%= button_to "Approve", admin_hackathon_approval_path(@hackathon), disabled: @hackathon.approved?, class: "button--success" %>
+    <%= button_to "Reject", admin_hackathon_rejection_path(@hackathon), disabled: @hackathon.rejected?, class: "button--danger" %>
+    <%= button_to "Hold for review", admin_hackathon_hold_path(@hackathon), disabled: @hackathon.pending?, class: "button--neutral" %>
   </div>
 
   <%= render "events/timeline", {eventable: @hackathon} %>


### PR DESCRIPTION
An explicit hold's purpose is to just mark that someone is on it, but waiting for something (clarification, edit, etc.), so we shouldn't require it to change a decision.