### PR TITLE
Fix Rails >= 7.1 reporting by updating AppSignal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -112,7 +112,7 @@ GEM
       faraday (>= 1.0, < 3.0)
       faraday-net_http_persistent
       net-http-persistent
-    appsignal (3.4.12)
+    appsignal (3.4.13)
       rack
     ast (2.4.2)
     audits1984 (0.1.4)


### PR DESCRIPTION
The AppSignal Ruby gem has better support for Rails 7.1 and higher with the latest patch release. Update the gem to see event timeline reporting and group breakdowns.