### PR TITLE
Ask for UTC times (not local times) from applicants

### DIFF
--- a/app/views/hackathons/submissions/_form.html.erb
+++ b/app/views/hackathons/submissions/_form.html.erb
@@ -17,7 +17,7 @@
   <div class="form__inputs">
     <%= f.input :name, label: "Name of the hackathon" %>
 
-    <%= f.input :starts_at, label: "Start date", hint: "Please enter this in local time", html5: true %>
+    <%= f.input :starts_at, label: "Start date", hint: "Please enter this in UTC time", html5: true %>
     <%= f.input :ends_at, label: "End date", hint: "and this too!", html5: true %>
 
     <% website_hint = capture do %>


### PR DESCRIPTION
We don't have logic to handle different time zones, and don't really need to as long as reviewers are aware times are submitted in UTC. We do, however, use [local_time](https://github.com/basecamp/local_time) to render most timestamps in the time zone of client devices.