### PR TITLE
Handle archive attempts for unresponsive websites

### DIFF
--- a/app/models/hackathon/website.rb
+++ b/app/models/hackathon/website.rb
@@ -25,7 +25,7 @@ module Hackathon::Website
   end
 
   def website_likely_associated?
-    website_response.body&.downcase&.include?(name.downcase)
+    website_response&.body&.downcase&.include?(name.downcase)
   end
 
   private

--- a/app/models/hackathon/website/archivable.rb
+++ b/app/models/hackathon/website/archivable.rb
@@ -1,10 +1,6 @@
 module Hackathon::Website::Archivable
   extend ActiveSupport::Concern
 
-  included do
-    after_create_commit :archive_website_later
-  end
-
   def website_or_archive_url
     if website_down? && website_archived?
       "https://web.archive.org/#{website.sub(/^https?:\/\/(www.)?/, "")}"
@@ -44,11 +40,5 @@ module Hackathon::Website::Archivable
     rescue Timeout::Error
       Rails.logger.info "Timed out waiting for Internet Archive to finish capture for #{website} with job #{capture.job_id}."
     end
-  end
-
-  private
-
-  def archive_website_later
-    Hackathons::ArchiveWebsiteJob.perform_later(self)
   end
 end

--- a/app/models/hackathon/website/archivable.rb
+++ b/app/models/hackathon/website/archivable.rb
@@ -1,6 +1,10 @@
 module Hackathon::Website::Archivable
   extend ActiveSupport::Concern
 
+  included do
+    after_create_commit :archive_website_later
+  end
+
   def website_or_archive_url
     if website_down? && website_archived?
       "https://web.archive.org/#{website.sub(/^https?:\/\/(www.)?/, "")}"
@@ -40,5 +44,11 @@ module Hackathon::Website::Archivable
     rescue Timeout::Error
       Rails.logger.info "Timed out waiting for Internet Archive to finish capture for #{website} with job #{capture.job_id}."
     end
+  end
+
+  private
+
+  def archive_website_later
+    Hackathons::ArchiveWebsiteJob.perform_later(self)
   end
 end


### PR DESCRIPTION
#318 was caused by a hackathon being submitted with an invalid (unreachable) site. This shouldn't have been possible, since `Hackathon#eligible_for_archive?` checks if the website is marked as up, and the `ArchiveWebsiteJob` only archives the website if that conditional is met. However, we're also attempting to archive the site right after creation which bypasses the check (which would've passed anyway since the daily `RefreshWebsiteStatusesJob` wouldn't have processed the site yet.