### PR TITLE
Show hackathon start/end times absolutely

### DIFF
--- a/app/views/admin/hackathons/_snippet.html.erb
+++ b/app/views/admin/hackathons/_snippet.html.erb
@@ -18,9 +18,9 @@
 
       <div class="hackathon-snippet__times">
         <span>Starts</span>
-        <span><%= local_time hackathon.starts_at %></span>
+        <span><%= time_tag(hackathon.starts_at, format: "%B %d, %Y at %l:%M %p") %></span>
         <span>Ends</span>
-        <span><%= local_time hackathon.ends_at %></span>
+        <span><%= time_tag(hackathon.ends_at, format: "%B %d, %Y at %l:%M %p") %> (UTC)</span>
       </div>
     </div>
   </article>

--- a/app/views/admin/hackathons/show.html.erb
+++ b/app/views/admin/hackathons/show.html.erb
@@ -57,8 +57,8 @@
 
     <div>
       <turbo-frame id="hackathon_times">
-        Starts <%= local_time_ago(@hackathon.starts_at) %>,
-        ends <%= local_time_ago(@hackathon.ends_at) %>
+        Starts <%= time_tag(@hackathon.starts_at, format: "%B %e, %Y at %l:%M %p") %>,
+        ends <%= time_tag(@hackathon.ends_at, format: "%B %e at %l:%M %p") %> (UTC)
         <%= link_to "✏️", edit_admin_hackathon_times_path(@hackathon), class: "hidden-link text--small" %>
       </turbo-frame>
     </div>


### PR DESCRIPTION
Relative time helpers make sense for things like (timelined) events and comments, but not when you wanna know when something's actually happening.