### PR TITLE
Disable YJIT and return to 2 web processes

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -29,6 +29,7 @@ registry:
 env:
   clear:
     HOST: dash.hackathons.hackclub.com
+    WEB_CONCURRENCY: 2
     RAILS_MAX_THREADS: 10
     RAILS_MIN_THREADS: 5
     APP_REVISION: <%= `git rev-parse HEAD`.strip %>

--- a/config/initializers/yjit.rb
+++ b/config/initializers/yjit.rb
@@ -1,3 +1,0 @@
-Rails.application.config.after_initialize do
-  RubyVM::YJIT.enable
-end


### PR DESCRIPTION
There wasn't a notable decrease in response times with YJIT, and this way we're able to process more requests at once again.