### PR TITLE
Revert Rails update from `299900f` to `2c5fe6f`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/rails/rails.git
-  revision: 2c5fe6fa7aba4a10d56ff4ee54d26511e58dda3b
+  revision: 299900f4e50cae5e1d5104b7569eef7bd386e6f5
   specs:
     actioncable (7.2.0.alpha)
       actionpack (= 7.2.0.alpha)
@@ -274,7 +274,7 @@ GEM
       uri
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.4.10)
+    net-imap (0.4.9.1)
       date
       net-protocol
     net-pop (0.1.2)


### PR DESCRIPTION
Reverts #425, fixes #427.