### PR TITLE
Don't rate limit mail deliveries on our end

### DIFF
--- a/app/jobs/rate_limited_mail_delivery_job.rb
+++ b/app/jobs/rate_limited_mail_delivery_job.rb
@@ -1,5 +1,0 @@
-class RateLimitedMailDeliveryJob < ActionMailer::MailDeliveryJob
-  include RateLimitable
-
-  rate_limit to: 10, within: 1.second
-end

--- a/config/initializers/action_mailer_concurrency.rb
+++ b/config/initializers/action_mailer_concurrency.rb
@@ -1,1 +1,0 @@
-Rails.application.config.action_mailer.delivery_job = "RateLimitedMailDeliveryJob"


### PR DESCRIPTION
Not worth the hassle of using such a complex system, especially since there's no penalty / temp-ban SES gives us for exceeding the rate limit unlike the Internet Archive. If we need to, we can add error-based retries and backoff later.