### PR TITLE
Build libheif 1.23.2 from source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,32 @@ ENV RAILS_ENV="production" \
     BUNDLE_DEPLOYMENT="1" \
     BUNDLE_PATH="/usr/local/bundle" \
     BUNDLE_WITHOUT="development" \
-    RUBYOPT="--enable-frozen-string-literal"
+    RUBYOPT="--enable-frozen-string-literal" \
+    LD_LIBRARY_PATH="/usr/local/lib"
 
 
 FROM base AS build
 
+# Debian trixie's libheif 1.19.8 has an unfixed heap overflow that public image
+# uploads reach through libvips' heifload. Build a patched one and let
+# LD_LIBRARY_PATH shadow the distro package. ENABLE_PLUGIN_LOADING=NO compiles
+# the codecs in, avoiding a plugin/core ABI version mismatch.
+# https://github.com/strukturag/libheif/security/advisories/GHSA-g89c-p67h-r497
+ARG LIBHEIF_VERSION=1.23.2
+ARG LIBHEIF_SHA256=1405ed070421459b569ff49deab109b7f1a30a447e72a9b20a4154f774634a44
+
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y build-essential git pkg-config libyaml-dev libpq-dev libvips
+    apt-get install --no-install-recommends -y build-essential git pkg-config libyaml-dev libpq-dev libvips \
+      curl ca-certificates cmake libde265-dev libdav1d-dev libaom-dev && \
+    curl -sL "https://github.com/strukturag/libheif/archive/refs/tags/v${LIBHEIF_VERSION}.tar.gz" -o /tmp/libheif.tar.gz && \
+    echo "${LIBHEIF_SHA256}  /tmp/libheif.tar.gz" | sha256sum -c - && \
+    tar xz -C /tmp/ -f /tmp/libheif.tar.gz && \
+    cmake -S "/tmp/libheif-${LIBHEIF_VERSION}" -B /tmp/libheif-build --preset=release -DENABLE_PLUGIN_LOADING=NO && \
+    cmake --build /tmp/libheif-build -j "$(nproc)" && \
+    cmake --install /tmp/libheif-build && \
+    ldconfig && \
+    mkdir -p /opt/libheif && cp -a /usr/local/lib/libheif.so* /opt/libheif/ && \
+    rm -rf /tmp/libheif*
 
 COPY .ruby-version Gemfile Gemfile.lock ./
 RUN bundle install && \
@@ -30,7 +49,8 @@ RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
 FROM base
 
 RUN apt-get update -qq && \
-    apt-get install --no-install-recommends -y postgresql-common libvips curl ca-certificates lsb-release libjemalloc2 && \
+    apt-get install --no-install-recommends -y postgresql-common libvips curl ca-certificates lsb-release libjemalloc2 \
+      libde265-0 libdav1d7 libaom3 && \
     install -d /usr/share/postgresql-common/pgdg && curl -o /usr/share/postgresql-common/pgdg/apt.postgresql.org.asc --fail https://www.postgresql.org/media/keys/ACCC4CF8.asc && \
     sh -c 'echo "deb [signed-by=/usr/share/postgresql-common/pgdg/apt.postgresql.org.asc] https://apt.postgresql.org/pub/repos/apt $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list' && \
     apt-get update -qq && apt-get install --no-install-recommends -y postgresql-client && \
@@ -40,6 +60,10 @@ ENV LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2
 
 COPY --from=build /usr/local/bundle /usr/local/bundle
 COPY --from=build /hackathons /hackathons
+
+# Copy the staged directory, not a glob: COPY dereferences the soname symlinks.
+COPY --from=build /opt/libheif/ /usr/local/lib/
+RUN ldconfig
 
 RUN useradd hackathons --create-home --shell /bin/bash && \
     chown -R hackathons:hackathons db log storage tmp


### PR DESCRIPTION
## What

Builds libheif 1.23.2 in the Docker build stage from a pinned tarball, and lets `LD_LIBRARY_PATH` shadow the Debian package at runtime.

## Why

Debian trixie ships **libheif 1.19.8**, which has an unfixed heap buffer overflow in `scale_nearest_neighbor()` ([GHSA-g89c-p67h-r497](https://github.com/strukturag/libheif/security/advisories/GHSA-g89c-p67h-r497), fixed in 1.23.2). Upstream reports achieving RCE with it.

It is reachable here. `Hackathon::Branded` attaches `:logo` and `:banner`, validates against `ActiveStorage.variable_content_types` (which includes `image/heic`, `image/heif`, and `image/avif`), and builds named variants. Those uploads come from the public submissions form, and content type is sniffed from magic bytes, so a filename or declared-MIME check would not help.

Rails and `image_processing` 2.0 both call `Vips.block_untrusted(true)` at boot, but that does not cover HEIF here: libvips only started marking `heifload` untrusted in **8.18.6**, and trixie ships **8.16.1**. Confirmed against the base image that a HEIF file decodes with the block set.

## How

Same approach as [hackclub/auth](https://github.com/hackclub/auth), with one addition: `-DENABLE_PLUGIN_LOADING=NO` compiles the codecs in rather than using libheif's plugin architecture. That matters because libheif's plugin ABI is version-gated (trixie's plugins declare decoder API 3, a 1.23.2 core requires 5), and a mismatch produces a quiet `Unsupported_plugin_version` refusal rather than a crash. Compiling them in removes the failure mode entirely.

The `SHA256` was verified independently against the upstream tarball. The build stages the library into `/opt/libheif` with `cp -a` so the soname symlinks survive `COPY` instead of being dereferenced into three full copies of a 3MB library.

## Verification

Full image builds clean. In the built runtime image, asking the library its own version:

```
libheif 1.23.2 via libvips 8.16.1
decoded 64x64 3-band
loaded: /usr/local/lib/libheif.so.1.23.2
```

Debian's 1.19.8 is still on disk as a `libvips` dependency but is never loaded. HEIC and AVIF keep working, so there is no functional regression.
