### PR TITLE
Update libheif to 1.23.3 to patch more vulnerabilities

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,9 @@ FROM base AS build
 # uploads reach through libvips' heifload. Build a patched one and let
 # LD_LIBRARY_PATH shadow the distro package. ENABLE_PLUGIN_LOADING=NO compiles
 # the codecs in, avoiding a plugin/core ABI version mismatch.
-# https://github.com/strukturag/libheif/security/advisories/GHSA-g89c-p67h-r497
-ARG LIBHEIF_VERSION=1.23.2
-ARG LIBHEIF_SHA256=1405ed070421459b569ff49deab109b7f1a30a447e72a9b20a4154f774634a44
+# https://github.com/strukturag/libheif/security/advisories/GHSA-x8r2-mggj-j6wr
+ARG LIBHEIF_VERSION=1.23.3
+ARG LIBHEIF_SHA256=79e1f66059e55728e541b671f347e3fa787cedeb61170f4e75efe8aaee6ef59e
 
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y build-essential git pkg-config libyaml-dev libpq-dev libvips \


### PR DESCRIPTION
Public logo and banner uploads reach libheif through libvips, and the Docker image currently builds libheif 1.23.2. Version 1.23.3 fixes the critical [heap buffer overflow in uncompressed HEIF decoding](https://github.com/strukturag/libheif/security/advisories/GHSA-x8r2-mggj-j6wr) and [heap memory disclosure during RGB conversion](https://github.com/strukturag/libheif/security/advisories/GHSA-w7mc-p8jc-p853), among other security fixes.

Update the pinned version and SHA256, and point the Dockerfile comment at the current overflow advisory. The existing download URL, build options, and codec support are preserved.

Validation:
- Downloaded the exact tag archive used by the Dockerfile, calculated its SHA256, and verified the pin against it.
- Confirmed the archive contains the expected source directory and CMake configuration.
- Reviewed the remote diff: one file, three changed lines.
- Upstream declares 1.23.3 API- and ABI-compatible with 1.23.2 in the [release notes](https://github.com/strukturag/libheif/releases/tag/v1.23.3). Existing CI builds the full Docker image.